### PR TITLE
Fix duplicate lines in multi-threaded find output

### DIFF
--- a/dicom_utils/cli/find.py
+++ b/dicom_utils/cli/find.py
@@ -67,8 +67,10 @@ def main(args: argparse.Namespace) -> None:
     with ThreadPoolExecutor(args.jobs) as tp:
         for match in path.rglob(args.name):
             f = tp.submit(check_file, match, args)
-            f.add_done_callback(callback)
             futures.append(f)
+
+        for f in futures:
+            callback(f)
 
 
 def entrypoint():

--- a/tests/test_main/test_find.py
+++ b/tests/test_main/test_find.py
@@ -34,9 +34,13 @@ def test_find(dicom_folder, capsys, tmp_path):
         str(tmp_path),
     ]
     runpy.run_module("dicom_utils.cli.find", run_name="__main__", alter_sys=True)
-    captured = capsys.readouterr()
+    captured1 = capsys.readouterr()
+    runpy.run_module("dicom_utils.cli.find", run_name="__main__", alter_sys=True)
+    captured2 = capsys.readouterr()
+
     for p in dicom_folder:
-        assert str(p) in captured.out
+        assert str(p) in captured1.out
+    assert list(sorted(captured1)) == list(sorted(captured2))
 
 
 @pytest.mark.usefixtures("dicom_folder")


### PR DESCRIPTION
When finding parent directories with multiple threads, duplicate lines would appear in the output. This PR addresses the problem and adds a test to ensure consistency across calls of `dicomfind`.