### PR TITLE
Speed up dicom2img for 3D images

### DIFF
--- a/dicom_utils/visualize.py
+++ b/dicom_utils/visualize.py
@@ -200,17 +200,16 @@ def dcms_to_images(dcms: List[Dicom], bar: bool = True, jobs: int = 4, **kwargs)
             return DicomImage.from_dicom(dcm, **kwargs)
         except Exception as e:
             logger.info(e)
-            return None
+            return
 
     def callback(f: Future):
         tqdm_bar.update(1)
 
     futures: List[Future] = []
     with ThreadPoolExecutor(jobs) as tp:
-        for dcm in dcms:
-            f = tp.submit(func, dcm)
+        futures: List[Future] = [tp.submit(func, dcm) for dcm in dcms]
+        for f in futures:
             f.add_done_callback(callback)
-            futures.append(f)
 
         for f in futures:
             if result := f.result():

--- a/dicom_utils/visualize.py
+++ b/dicom_utils/visualize.py
@@ -200,12 +200,10 @@ def dcms_to_images(dcms: List[Dicom], bar: bool = True, jobs: int = 4, **kwargs)
             return DicomImage.from_dicom(dcm, **kwargs)
         except Exception as e:
             logger.info(e)
-            return
 
     def callback(f: Future):
         tqdm_bar.update(1)
 
-    futures: List[Future] = []
     with ThreadPoolExecutor(jobs) as tp:
         futures: List[Future] = [tp.submit(func, dcm) for dcm in dcms]
         for f in futures:

--- a/dicom_utils/volume.py
+++ b/dicom_utils/volume.py
@@ -95,7 +95,7 @@ class SliceAtLocation(VolumeHandler):
 
     Args:
         center:
-            The slice about which to sample
+            The slice about which to sample. Defaults to num_frames / 2
 
         before:
             Optional frames to sample before ``center``.
@@ -109,7 +109,7 @@ class SliceAtLocation(VolumeHandler):
 
     def __init__(
         self,
-        center: int,
+        center: Optional[int] = None,
         before: int = 0,
         after: int = 0,
         stride: int = 1,
@@ -128,8 +128,9 @@ class SliceAtLocation(VolumeHandler):
         return s
 
     def get_indices(self, total_frames: Optional[int]) -> Tuple[int, Optional[int], int]:
-        start = self.center - self.before
-        end = self.center + self.after + 1
+        center = self.center if self.center is not None else total_frames // 2
+        start = center - self.before
+        end = center + self.after + 1
         return start, end, self.stride
 
 

--- a/dicom_utils/volume.py
+++ b/dicom_utils/volume.py
@@ -127,7 +127,15 @@ class SliceAtLocation(VolumeHandler):
         s += ")"
         return s
 
-    def get_indices(self, total_frames: Optional[int]) -> Tuple[int, Optional[int], int]:
+    def slice_dicom(self, dcm: U) -> U:
+        num_frames: Optional[SupportsInt] = dcm.get("NumberOfFrames", None)
+        if num_frames is None and self.center is None:
+            raise AttributeError(f"`NumberOfFrames` cannot be absent when `{self.__class__.__name__}.center` is `None`")
+        return super().slice_dicom(dcm)
+
+    def get_indices(self, total_frames: Optional[int]) -> Tuple[int, int, int]:
+        if self.center is None and total_frames is None:
+            raise ValueError(f"`total_frames` cannot be `None` when `{self.__class__.__name__}.center` is `None`")
         center = self.center if self.center is not None else total_frames // 2
         start = center - self.before
         end = center + self.after + 1


### PR DESCRIPTION
Loading JPEG2000 compressed 3D images can take a long time (>30s). With this change, dicom2img will default to rendering only the center slice of a 3D volume. Also supports multi-threaded image loading