### PR TITLE
Add metadata container classes

### DIFF
--- a/dicom_utils/container/__init__.py
+++ b/dicom_utils/container/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from .helpers import SeriesUID, StudyUID, TransferSyntaxUID
+from .record import FileRecord, RecordCollection, record_iterator
+
+
+__all__ = [
+    "Series",
+    "Study",
+    "SeriesContainer",
+    "SeriesUID",
+    "StudyUID",
+    "record_iterator",
+    "FileRecord",
+    "RecordCollection",
+    "TransferSyntaxUID",
+]

--- a/dicom_utils/container/__init__.py
+++ b/dicom_utils/container/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .helpers import SeriesUID, StudyUID, TransferSyntaxUID
+from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID, TransferSyntaxUID
 from .record import FileRecord, RecordCollection, record_iterator
 
 
@@ -15,4 +15,6 @@ __all__ = [
     "FileRecord",
     "RecordCollection",
     "TransferSyntaxUID",
+    "SOPUID",
+    "ImageUID",
 ]

--- a/dicom_utils/container/helpers.py
+++ b/dicom_utils/container/helpers.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from typing import Union
 
 
 SeriesUID = str
 StudyUID = str
+SOPUID = str
 TransferSyntaxUID = str
+ImageUID = Union[SeriesUID, SOPUID]

--- a/dicom_utils/container/helpers.py
+++ b/dicom_utils/container/helpers.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+SeriesUID = str
+StudyUID = str
+TransferSyntaxUID = str

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -6,7 +6,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set
+from typing import Any, Dict, Final, Iterator, List, Optional, Sequence, Set, cast
 
 import pydicom
 from tqdm import tqdm
@@ -22,7 +22,7 @@ from .helpers import SeriesUID, StudyUID
 from .helpers import TransferSyntaxUID as TSUID
 
 
-tags: List[Any] = [
+tags: Final = [
     Tag.SeriesInstanceUID,
     Tag.StudyInstanceUID,
     Tag.SOPInstanceUID,
@@ -86,7 +86,7 @@ class FileRecord:
         if not path.is_file():
             raise FileNotFoundError(path)
 
-        with pydicom.dcmread(path, stop_before_pixels=True, specific_tags=tags) as dcm:
+        with pydicom.dcmread(path, stop_before_pixels=True, specific_tags=cast(List[Any], tags)) as dcm:
             values = {tag.name: getattr(dcm, tag.name, None) for tag in tags}
             for key in ("Rows", "Columns", "NumberOfFrames"):
                 values[key] = int(values[key]) if values[key] else None

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -18,7 +18,7 @@ from ..tags import Tag
 from ..types import ImageType
 from ..types import PhotometricInterpretation as PI
 from ..types import SimpleImageType as SIT
-from .helpers import SeriesUID, StudyUID
+from .helpers import SOPUID, SeriesUID, StudyUID
 from .helpers import TransferSyntaxUID as TSUID
 
 
@@ -48,7 +48,7 @@ class FileRecord:
     path: Path
     StudyInstanceUID: Optional[StudyUID]
     SeriesInstanceUID: Optional[SeriesUID]
-    SOPInstanceUID: Optional[SeriesUID]
+    SOPInstanceUID: Optional[SOPUID]
 
     TransferSyntaxUID: Optional[TSUID]
 

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set
+
+import pydicom
+from tqdm import tqdm
+
+from ..tags import Tag
+
+# Type checking fails when dataclass attr name matches a type alias.
+# Import types under a different alias
+from ..types import ImageType
+from ..types import PhotometricInterpretation as PI
+from ..types import SimpleImageType as SIT
+from .helpers import SeriesUID, StudyUID
+from .helpers import TransferSyntaxUID as TSUID
+
+
+tags: List[Any] = [
+    Tag.SeriesInstanceUID,
+    Tag.StudyInstanceUID,
+    Tag.SOPInstanceUID,
+    Tag.TransferSyntaxUID,
+    Tag.Rows,
+    Tag.Columns,
+    Tag.NumberOfFrames,
+    Tag.PhotometricInterpretation,
+    Tag.ImageType,
+    Tag.ManufacturerModelName,
+    Tag.SeriesDescription,
+    Tag.PatientName,
+    Tag.PatientID,
+]
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    r"""Data structure for storing critical information about a DICOM file.
+    File IO operations on DICOMs can be expensive, so this class collects all
+    required information in a single pass to avoid repeated file opening.
+    """
+    path: Path
+    StudyInstanceUID: Optional[StudyUID]
+    SeriesInstanceUID: Optional[SeriesUID]
+    SOPInstanceUID: Optional[SeriesUID]
+
+    TransferSyntaxUID: Optional[TSUID]
+
+    Rows: Optional[int] = None
+    Columns: Optional[int] = None
+    NumberOfFrames: Optional[int] = None
+    PhotometricInterpretation: Optional[PI] = None
+    SimpleImageType: Optional[SIT] = None
+    ManufacturerModelName: Optional[str] = None
+    SeriesDescription: Optional[str] = None
+
+    PatientName: Optional[str] = None
+    PatientID: Optional[str] = None
+
+    def __hash__(self) -> int:
+        return hash(self.path)
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, FileRecord) and self.path == other.path
+
+    @property
+    def is_image(self) -> bool:
+        return bool(self.Rows and self.Columns and self.PhotometricInterpretation)
+
+    @property
+    def is_volume(self) -> bool:
+        return self.is_image and ((self.NumberOfFrames or 1) > 1)
+
+    @property
+    def file_size(self) -> int:
+        return self.path.stat().st_size
+
+    @classmethod
+    def create(cls, path: Path) -> "FileRecord":
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+        with pydicom.dcmread(path, stop_before_pixels=True, specific_tags=tags) as dcm:
+            values = {tag.name: getattr(dcm, tag.name, None) for tag in tags}
+            for key in ("Rows", "Columns", "NumberOfFrames"):
+                values[key] = int(values[key]) if values[key] else None
+            img_type = ImageType.from_dicom(dcm).to_simple_image_type()
+            values["TransferSyntaxUID"] = dcm.file_meta.get("TransferSyntaxUID", None)
+
+        values.pop("ImageType")
+        return cls(path, SimpleImageType=img_type, **values)
+
+
+def record_iterator(
+    files: Sequence[Path], jobs: Optional[int] = None, use_bar: bool = True, threads: bool = False
+) -> Iterator[FileRecord]:
+    r"""Produces :class:`FileRecord` instances by iterating over an input list of files. If a
+    :class:`FileRecord` cannot be created from a path, it will be ignored.
+
+    Args:
+        files:
+            List of paths to iterate over
+
+        jobs:
+            Number of parallel processes to use
+
+        use_bar:
+            If ``False``, don't show a tqdm progress bar
+
+        threads:
+            If ``True``, use a :class:`ThreadPoolExecutor`. Otherwise, use a :class:`ProcessPoolExecutor`
+
+    Returns:
+        Iterator of :class:`FileRecord`s
+    """
+    files = list(p for p in files if p.is_file())
+    bar = tqdm(desc="Scanning files", total=len(files), unit="file", disable=(not use_bar))
+
+    def callback(f):
+        bar.update(1)
+
+    futures = []
+    Pool = ThreadPoolExecutor if threads else ProcessPoolExecutor
+    with Pool(jobs) as p:
+        for path in files:
+            f = p.submit(FileRecord.create, path)
+            f.add_done_callback(callback)
+            futures.append(f)
+
+        for path, f in zip(files, futures):
+            if f.exception():
+                continue
+            elif record := f.result():
+                yield record
+    bar.close()
+
+
+class RecordCollection:
+    r"""Data stucture for organizing :class:`FileRecord` instances, indexed by various attriburtes."""
+
+    def __init__(self):
+        self._lookup: Dict[Path, FileRecord] = {}
+
+    def __len__(self) -> int:
+        r"""Returns the total number of contained records"""
+        return len(self._lookup)
+
+    @property
+    def path_lookup(self) -> Dict[Path, FileRecord]:
+        r"""Returns a dictionary mapping a filepath to a :class:`FileRecord`"""
+        return self._lookup
+
+    @cached_property
+    def study_lookup(self) -> Dict[StudyUID, Set[FileRecord]]:
+        r"""Returns a dictionary mapping a StudyInstanceUID to a set of :class:`FileRecord`s with
+        that StudyInstanceUID. Records missing a StudyInstanceUID are ignored.
+        """
+        result: Dict[StudyUID, Set[FileRecord]] = {}
+        for record in self._lookup.values():
+            if record.StudyInstanceUID is None:
+                continue
+            record_set = result.get(record.StudyInstanceUID, set())
+            record_set.add(record)
+            result[record.StudyInstanceUID] = record_set
+        return result
+
+    @classmethod
+    def from_dir(
+        cls,
+        path: Path,
+        pattern: str = "*",
+        jobs: Optional[int] = None,
+        use_bar: bool = True,
+        threads: bool = False,
+        ignore_patterns: Sequence[str] = [],
+    ) -> "RecordCollection":
+        r"""Create a :class:`RecordCollection` from files in a directory matching a wildcard.
+        If a :class:`FileRecord` cannot be created for a file, that file is silently excluded
+        from the collection.
+
+        Args:
+            path:
+                Path to the directory to search
+
+            pattern:
+                Glob pattern for matching files
+
+            jobs:
+                Number of parallel jobs to use
+
+            use_bar:
+                If ``False``, don't show a tqdm progress bar
+
+            threads:
+                If ``True``, use a :class:`ThreadPoolExecutor`. Otherwise, use a :class:`ProcessPoolExecutor`
+
+            ignore_patterns:
+                Strings indicating files that should be ignored. Matching is a simple ``str(pattern) in str(filepath)``.
+        """
+        if not path.is_dir():
+            raise NotADirectoryError(path)
+        files = [p for p in path.rglob(pattern) if not any(ignore in str(p) for ignore in ignore_patterns)]
+        return cls.from_files(files, jobs, use_bar, threads)
+
+    @classmethod
+    def from_files(
+        cls,
+        files: Sequence[Path],
+        jobs: Optional[int] = None,
+        use_bar: bool = True,
+        threads: bool = False,
+    ) -> "RecordCollection":
+        r"""Create a :class:`RecordCollection` from a list of files.
+        If a :class:`FileRecord` cannot be created for a file, that file is silently excluded
+        from the collection.
+
+        Args:
+            files:
+                List of files to create records from
+
+            jobs:
+                Number of parallel jobs to use
+
+            use_bar:
+                If ``False``, don't show a tqdm progress bar
+
+            threads:
+                If ``True``, use a :class:`ThreadPoolExecutor`. Otherwise, use a :class:`ProcessPoolExecutor`
+
+            ignore_patterns:
+                Strings indicating files that should be ignored. Matching is a simple ``str(pattern) in str(filepath)``.
+        """
+        collection = cls()
+        for record in record_iterator(files, jobs, use_bar, threads):
+            collection._lookup[record.path] = record
+        return collection

--- a/tests/test_container/conftest.py
+++ b/tests/test_container/conftest.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import shutil
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+
+import pydicom
+import pytest
+
+from dicom_utils.container import FileRecord, RecordCollection, record_iterator
+from dicom_utils.types import SimpleImageType
+
+
+class TestFileRecord:
+    def test_create(self, dicom_file):
+        rec = FileRecord.create(Path(dicom_file))
+        dcm = pydicom.dcmread(dicom_file)
+        assert rec.path == Path(dicom_file)
+        assert rec.StudyInstanceUID == dcm.StudyInstanceUID
+        assert rec.SeriesInstanceUID == dcm.SeriesInstanceUID
+        assert rec.SOPInstanceUID == dcm.SOPInstanceUID
+        assert rec.TransferSyntaxUID == dcm.file_meta.TransferSyntaxUID
+        assert rec.Rows == dcm.Rows
+        assert rec.Columns == dcm.Columns
+        assert rec.NumberOfFrames == dcm.get("NumberOfFrames", None)
+        assert rec.PhotometricInterpretation == dcm.PhotometricInterpretation
+        assert rec.SimpleImageType == SimpleImageType.NORMAL
+        assert rec.ManufacturerModelName == dcm.ManufacturerModelName
+        assert rec.SeriesDescription == dcm.get("SeriesDescription", None)
+        assert rec.PatientName == dcm.get("PatientName", None)
+        assert rec.PatientID == dcm.get("PatientID", None)
+
+    @pytest.fixture
+    def record(self, dicom_file):
+        return FileRecord.create(Path(dicom_file))
+
+    def test_hash(self, record):
+        assert hash(record) == hash(record.path)
+
+    def test_eq(self, record):
+        rec2 = replace(record, path=Path("foo/bar.dcm"))
+        rec3 = deepcopy(record)
+        assert record != "dog"
+        assert record != rec2
+        assert record == rec3
+        assert rec3 == record
+
+    def test_file_size(self, record):
+        assert record.file_size == record.path.stat().st_size
+
+    @pytest.mark.parametrize(
+        "rows,columns,nf,exp",
+        [
+            pytest.param(100, 100, 100, True),
+            pytest.param(100, 100, None, True),
+            pytest.param(None, 100, None, False),
+            pytest.param(100, None, None, False),
+            pytest.param(None, None, None, False),
+        ],
+    )
+    def test_is_image(self, record, rows, columns, nf, exp):
+        record = replace(record, Rows=rows, Columns=columns, NumberOfFrames=nf)
+        assert record.is_image == exp
+
+    @pytest.mark.parametrize(
+        "rows,columns,nf,exp",
+        [
+            pytest.param(100, 100, 100, True),
+            pytest.param(100, 100, 1, False),
+            pytest.param(100, 100, None, False),
+            pytest.param(None, 100, 100, False),
+            pytest.param(None, 100, None, False),
+            pytest.param(100, None, None, False),
+            pytest.param(None, None, None, False),
+        ],
+    )
+    def test_is_volume(self, record, rows, columns, nf, exp):
+        record = replace(record, Rows=rows, Columns=columns, NumberOfFrames=nf)
+        assert record.is_volume == exp
+
+
+@pytest.fixture
+def dicom_files(tmp_path, dicom_file):
+    paths = []
+    for i in range(3):
+        for j in range(3):
+            dest = Path(tmp_path, f"subdir_{i}", f"file_{j}.dcm")
+            dest.parent.mkdir(exist_ok=True, parents=True)
+            shutil.copy(dicom_file, str(dest))
+            paths.append(dest)
+    return paths
+
+
+@pytest.mark.parametrize("use_bar", [True, False])
+@pytest.mark.parametrize("threads", [False, True])
+@pytest.mark.parametrize("jobs", [None, 1, 2])
+def test_record_iterator(dicom_files, use_bar, threads, jobs):
+    records = record_iterator(dicom_files, jobs, use_bar, threads)
+    assert set(rec.path for rec in records) == set(dicom_files)
+
+
+class TestRecordCollection:
+    @pytest.mark.parametrize("use_bar", [True, False])
+    @pytest.mark.parametrize("threads", [False, True])
+    @pytest.mark.parametrize("jobs", [None, 1, 2])
+    def test_from_files(self, dicom_files, use_bar, threads, jobs):
+        col = RecordCollection.from_files(dicom_files, jobs, use_bar, threads)
+        assert set(col.path_lookup.keys()) == set(dicom_files)
+        assert all(isinstance(v, FileRecord) for v in col.path_lookup.values())
+        assert set(v.path for v in col.path_lookup.values()) == set(dicom_files)
+
+    @pytest.mark.parametrize("use_bar", [True, False])
+    @pytest.mark.parametrize("threads", [False, True])
+    @pytest.mark.parametrize("jobs", [None, 1, 2])
+    def test_from_dir(self, tmp_path, dicom_files, use_bar, threads, jobs):
+        col = RecordCollection.from_dir(tmp_path, "*.dcm", jobs, use_bar, threads)
+        assert set(col.path_lookup.keys()) == set(dicom_files)
+        assert all(isinstance(v, FileRecord) for v in col.path_lookup.values())
+        assert set(v.path for v in col.path_lookup.values()) == set(dicom_files)
+
+    @pytest.fixture
+    def collection(self, dicom_files):
+        return RecordCollection.from_files(dicom_files)
+
+    def test_len(self, collection, dicom_files):
+        assert len(collection) == len(dicom_files)
+
+    def test_study_lookup(self, collection, dicom_files):
+        lookup = collection.study_lookup
+        assert len(lookup) == 1
+        records = lookup["1.3.6.1.4.1.5962.1.2.1.20040119072730.12322"]
+        assert len(records) == len(dicom_files)
+        assert all(isinstance(r, FileRecord) for r in records)


### PR DESCRIPTION
Adds container classes that can be used to retrieve essential metadata about a DICOM file or files. Integrating `Study` and `Series` instances from medcog_preprocessing proved difficult due to tight coupling with features specific to our use case (blacklisting, IDS/PIL image reading, etc). This solution is more application agnostic and likely more performant. 

Supports the following features:
1. Read and store essential metadata once, avoiding redundant file opens
2. Scan and collect metadata for a file list or directory + wildcard pattern
3. Aggregate contained records by an arbitrary metadata field (e.g. StudyInstanceUID)

Adds the following classes/methods:
* `FileRecord` - data structure for essential metadata
* `RecordCollection` - container for multiple `FileRecords`, aggregated by arbitrary fields
* `record_iterator` - method for scanning/iteratoring over `FileRecord`s produced frrom a file list 