### PR TITLE
Support python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
 jobs:
     check_code_quality:
         docker:
-            - image: circleci/python:3.8.3-buster
+            - image: circleci/python:3.10
         steps:
             - checkout
             - run: 
@@ -30,7 +30,7 @@ jobs:
 
     run_tests:
         docker:
-            - image: circleci/python:3.8.3-buster
+            - image: circleci/python:3.10
         steps:
             - checkout
             - run:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-.PHONY: clean clean-venv check quality style tag-version test venv upload upload-test
+.PHONY: clean clean-env check quality style tag-version test env upload upload-test
 
 PROJECT=dicom_utils
-PY_VER=python3.8
+PY_VER=python3.10
 PY_VER_SHORT=py$(shell echo $(PY_VER) | sed 's/[^0-9]*//g')
 QUALITY_DIRS=$(PROJECT) tests setup.py tag_enum.py
 CLEAN_DIRS=$(PROJECT) tests
-VENV=$(shell pwd)/venv
+VENV=$(shell pwd)/env
 PYTHON=$(VENV)/bin/python
 
 LINE_LEN=120
@@ -31,14 +31,14 @@ clean: ## remove cache files
 	find $(CLEAN_DIRS) -name '*.pyc' -type f -delete
 	find $(CLEAN_DIRS) -name '*,cover' -type f -delete
 
-clean-venv: ## remove the virtual environment directory
+clean-env: ## remove the virtual environment directory
 	rm -rf $(VENV)
 
 init: ## pulls submodules and initializes virtual environment
 	git submodule update --init --recursive
 	$(MAKE) $(VENV)/bin/activate
 
-package: venv
+package: env
 	rm -rf dist
 	$(PYTHON) -m pip install --upgrade setuptools wheel
 	export $(PROJECT)_BUILD_VERSION=$(VERSION) && $(PYTHON) setup.py sdist bdist_wheel
@@ -101,7 +101,7 @@ upload-test: package
 	$(PYTHON) -m pip install --upgrade twine
 	$(PYTHON) -m twine upload --repository testpypi dist/*
 
-venv: $(VENV)/bin/activate ## create a virtual environment for the project
+env: $(VENV)/bin/activate ## create a virtual environment for the project
 
 $(VENV)/bin/activate: setup.py requirements.txt
 	test -d $(VENV) || $(PY_VER) -m venv $(VENV)
@@ -121,7 +121,7 @@ help: ## display this help message
 
 reset:
 	$(MAKE) clean
-	$(MAKE) clean-venv
+	$(MAKE) clean-env
 	$(MAKE) init
 	$(MAKE) $(VENV)/bin/activate-test
 	$(MAKE) check

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -200,7 +200,7 @@ def read_dicom_image(
 
     # return random pixel data in correct shape when stop_before_pixels=True
     if stop_before_pixels:
-        return np.random.randint(0, 2 ** 10, dims)
+        return np.random.randint(0, 2**10, dims)
 
     # apply volume handling for 3D data
     if len(dims) == 4:

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -363,8 +363,8 @@ class Laterality(EnumMixin):
                     .get(Tag.FrameLaterality)
                     .value
                 )
-            except Exception as ex:
-                print(ex)
+            except Exception:
+                pass
 
         if isinstance(laterality, str):
             laterality = laterality.strip().lower()

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,4 @@
 {
 	"venvPath": ".",
-	"venv": "venv"
+	"venv": "env"
 }

--- a/requirements.quality.txt
+++ b/requirements.quality.txt
@@ -1,5 +1,5 @@
-autoflake==1.4
-autopep8==1.5.4
-black==21.12b0
-flake8==3.8.4
-isort==5.6.4
+autoflake>=1.4
+autopep8>=1.5.4
+black>=21.12b0
+flake8>=3.8.4
+isort>=5.6.4

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def install(version):
             "opencv-python",
         ],
         extras_require=extras,
-        python_requires=">=3.7.0,<3.10",
+        python_requires=">=3.7.0",
         entry_points={
             "console_scripts": [
                 "dicomutils = dicom_utils.cli.__main__:main",


### PR DESCRIPTION
Includes the following changes:
* Relaxes Python version requirement to support Python 3.10
* Upgrades CI instance version to Python 3.10
* Renames `venv` -> `env` to adopt new naming standard
* Relaxes quality library requirements (needed to support 3.10)