### PR TITLE
Use pydicom to properly apply window levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ test: $(VENV)/bin/activate-test ## run unit tests
 		--cov=./$(PROJECT) \
 		--cov-report=xml \
 		--cov-report=term \
-		-s -v \
 		./tests/
 
 test-%: $(VENV)/bin/activate-test ## run unit tests matching a pattern

--- a/dicom_utils/cli/dicom2img.py
+++ b/dicom_utils/cli/dicom2img.py
@@ -30,7 +30,6 @@ def get_parser(parser: ArgumentParser = ArgumentParser()) -> ArgumentParser:
     parser.add_argument("-f", "--fps", default=5, type=int, help="framerate for animated outputs")
     parser.add_argument("-q", "--quality", default=95, type=int, help="quality of outputs, from 1 to 100")
     parser.add_argument("--noblock", default=False, action="store_true", help="allow matplotlib to block")
-    parser.add_argument("--window", default=False, action="store_true", help="apply window from DICOM metadata")
     parser.add_argument("-b", "--bytes", default=False, action="store_true", help="output a png image as a byte stream")
     return parser
 
@@ -202,7 +201,6 @@ def main(args: argparse.Namespace) -> None:
         not args.noblock,
         args.bytes,
         args.downsample,
-        apply_window=args.window,
     )
 
 

--- a/dicom_utils/visualize.py
+++ b/dicom_utils/visualize.py
@@ -326,6 +326,7 @@ def dcms_to_annotated_images(dcms: List[Dicom], **kwargs) -> List[DicomImage]:
 
 
 def to_8bit(x: ndarray) -> ndarray:
-    min, max = x.min(), x.max()
-    x = (x - min) / (max - min) * 255
+    pixel_min, pixel_max = x.min(), x.max()
+    delta = max(pixel_max - pixel_min, 1e-9)
+    x = (x - pixel_min) / delta * 255
     return x.round().astype(np.uint8)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 markers =
     ci_skip: skip tests in CI environment
+
+filterwarnings =
+    ignore:.*Invalid value for VR.*:UserWarning

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -7,11 +7,9 @@ import time
 import numpy as np
 import pydicom
 import pytest
-from pydicom import DataElement
 
 from dicom_utils import KeepVolume, SliceAtLocation, UniformSample, read_dicom_image
 from dicom_utils.dicom import data_handlers, default_data_handlers, is_inverted
-from dicom_utils.types import WINDOW_CENTER, WINDOW_WIDTH, Window
 
 
 class TestReadDicomImage:
@@ -84,56 +82,6 @@ class TestReadDicomImage:
         spy.assert_called_once()
         assert spy.mock_calls[0].args[0] == dcm, "handler should be called with DICOM object"
         assert array1.ndim < 4 or array1.shape[1] != 1, "3D dim should be squeezed when D=1"
-
-    @pytest.mark.parametrize(
-        "apply,center,width",
-        [
-            pytest.param(True, None, None),
-            pytest.param(True, DataElement(WINDOW_CENTER, "DS", 512), None),
-            pytest.param(True, None, DataElement(WINDOW_WIDTH, "DS", 512)),
-            pytest.param(True, DataElement(WINDOW_CENTER, "DS", 512), DataElement(WINDOW_WIDTH, "DS", 256)),
-            pytest.param(True, DataElement(WINDOW_CENTER, "DS", 256), DataElement(WINDOW_WIDTH, "DS", 512)),
-            pytest.param(
-                True,
-                DataElement(WINDOW_CENTER, "DS", [100, 200, 300]),
-                DataElement(WINDOW_WIDTH, "DS", [200, 300, 400]),
-            ),
-            pytest.param(False, DataElement(WINDOW_CENTER, "DS", 512), DataElement(WINDOW_WIDTH, "DS", 256)),
-            pytest.param(False, DataElement(WINDOW_CENTER, "DS", 256), DataElement(WINDOW_WIDTH, "DS", 512)),
-            pytest.param(
-                False,
-                DataElement(WINDOW_CENTER, "DS", [100, 200, 300]),
-                DataElement(WINDOW_WIDTH, "DS", [200, 300, 400]),
-            ),
-        ],
-    )
-    def test_apply_window(self, dicom_object, apply, center, width):
-        # set metadata
-        if center is not None:
-            dicom_object[WINDOW_CENTER] = center
-        if width is not None:
-            dicom_object[WINDOW_WIDTH] = width
-
-        window = Window.from_dicom(dicom_object)
-        pixels = read_dicom_image(dicom_object, apply_window=False)
-        window_pixels = read_dicom_image(dicom_object, apply_window=apply)
-
-        if center is not None and width is not None and apply:
-            assert (window_pixels >= 0).all()
-            assert (window_pixels <= window.width).all()
-            assert (window_pixels[pixels <= window.lower_bound] == 0).all()
-            assert (window_pixels[pixels >= window.upper_bound] == window.upper_bound - window.lower_bound).all()
-
-        elif apply:
-            pixels = dicom_object.pixel_array
-            assert window_pixels.min() == 0
-            # tolerance of 1 here for rounding errors
-            assert window_pixels.max() - (pixels.max() - pixels.min()) <= 1
-
-        else:
-            assert (window_pixels == pixels).all()
-
-        window = Window.from_dicom(dicom_object)
 
     def test_decoding_speed(self, dicom_file_j2k: str) -> None:
         # Make sure that our set of pixel data handlers is actually faster than the default set

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,23 +3,13 @@
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, cast
+from typing import Any, Dict, cast
 
-import numpy as np
 import pytest
 from pydicom import DataElement
 
 from dicom_utils.tags import Tag
-from dicom_utils.types import (
-    WINDOW_CENTER,
-    WINDOW_WIDTH,
-    ImageType,
-    Laterality,
-    MammogramType,
-    PhotometricInterpretation,
-    ViewPosition,
-    Window,
-)
+from dicom_utils.types import ImageType, Laterality, MammogramType, PhotometricInterpretation, ViewPosition
 
 
 @dataclass
@@ -173,85 +163,6 @@ class TestMammogramType:
     )
     def test_from_str(self, input_str, expected):
         assert expected == MammogramType.from_str(input_str)
-
-
-class TestWindow:
-    @pytest.mark.parametrize(
-        "center,width",
-        [
-            pytest.param(None, None),
-            pytest.param(DataElement(WINDOW_CENTER, "DS", 512), None),
-            pytest.param(None, DataElement(WINDOW_WIDTH, "DS", 512)),
-            pytest.param(DataElement(WINDOW_CENTER, "DS", 512), DataElement(WINDOW_WIDTH, "DS", 256)),
-            pytest.param(DataElement(WINDOW_CENTER, "DS", 256), DataElement(WINDOW_WIDTH, "DS", 512)),
-            pytest.param(
-                DataElement(WINDOW_CENTER, "DS", [100, 200, 300]), DataElement(WINDOW_WIDTH, "DS", [200, 300, 400])
-            ),
-        ],
-    )
-    def test_from_dicom(self, dicom_object, center, width):
-        if center is not None:
-            dicom_object[WINDOW_CENTER] = center
-        if width is not None:
-            dicom_object[WINDOW_WIDTH] = width
-
-        window = Window.from_dicom(dicom_object)
-
-        if center is not None and width is not None:
-            assert window.center == center.value if not isinstance(center.value, Iterable) else center[0]
-            assert window.width == width.value if not isinstance(width.value, Iterable) else width[0]
-        else:
-            pixels = dicom_object.pixel_array
-            assert window.center == (pixels.max() - pixels.min()) // 2 + pixels.min()
-            assert window.width == pixels.max() - pixels.min()
-
-    def test_repr(self):
-        window = Window(100, 300)
-        print(window)
-
-    @pytest.mark.parametrize(
-        "center,width,expected",
-        [
-            pytest.param(200, 100, 150),
-            pytest.param(100, 200, 0),
-            pytest.param(100, 300, 0),
-        ],
-    )
-    def test_lower_bound(self, center, width, expected):
-        window = Window(center, width)
-        assert window.lower_bound == expected
-
-    @pytest.mark.parametrize(
-        "center,width,expected",
-        [
-            pytest.param(200, 100, 250),
-            pytest.param(100, 200, 200),
-            pytest.param(100, 300, 250),
-        ],
-    )
-    def test_upper_bound(self, center, width, expected):
-        window = Window(center, width)
-        assert window.upper_bound == expected
-
-    @pytest.mark.parametrize(
-        "center,width",
-        [
-            pytest.param(200, 100),
-            pytest.param(100, 200),
-            pytest.param(100, 300),
-        ],
-    )
-    def test_apply(self, center, width):
-        np.random.seed(42)
-        pixels = np.random.random(100).reshape(10, 10)
-        pixels = (pixels * 1024).astype(np.uint16)
-        window = Window(center, width)
-
-        window_pixels = window.apply(pixels)
-        assert (window_pixels >= 0).all()
-        assert (window_pixels <= window.width).all()
-        assert (window_pixels[pixels <= window.lower_bound] == 0).all()
-        assert (window_pixels[pixels >= window.upper_bound] == window.upper_bound - window.lower_bound).all()
 
 
 class TestPhotometricInterpretation:


### PR DESCRIPTION
Accounts for VOI_LUT values that were not handled correctly, such as 'SIGMOID'.

Includes the following changes:
* Window levels will be applied by default using pydicom handlers
* Remove `Window` class
* Fix/filter some minor test-time warnings