### PR TITLE
Ensure factories have valid pixel data

### DIFF
--- a/tests/test_dicom_factory.py
+++ b/tests/test_dicom_factory.py
@@ -71,26 +71,32 @@ class TestDicomFactory:
         factory = FACTORY_REGISTRY.get("ffdm")()
         dcm = factory()
         assert MammogramType.from_dicom(dcm) == MammogramType.FFDM
+        assert dcm.pixel_array.any()
 
     def test_tomo_factory(self):
         factory = FACTORY_REGISTRY.get("tomo")()
         dcm = factory()
         assert MammogramType.from_dicom(dcm) == MammogramType.TOMO
+        assert dcm.pixel_array.any()
 
     def test_synth_factory(self):
         factory = FACTORY_REGISTRY.get("synth")()
         dcm = factory()
         assert MammogramType.from_dicom(dcm) == MammogramType.SYNTH
+        assert dcm.pixel_array.any()
 
     def test_ultrasound_factory(self):
         factory = FACTORY_REGISTRY.get("ultrasound")()
         dcm = factory()
         assert dcm.Modality == "US"
+        assert dcm.pixel_array.any()
 
     def test_complete_mammography_case_factory(self):
         factory = FACTORY_REGISTRY.get("mammo-case")()
         dicoms = factory()
         assert len(dicoms) == 12
+        for dcm in dicoms:
+            assert dcm.pixel_array.any()
 
     @pytest.mark.parametrize("allow", [True, False])
     def test_nonproto_tag(self, allow):


### PR DESCRIPTION
DICOM factory classes allow for changes to be made to attributes like Rows and Columns, but there are no checks/handling to ensure that the pixel data for the output DICOM object is valid after these changes. New values for Rows/Columns may not match the dimensions of the original pixel array. This PR adds a check to ensure valid pixel data for factory produced DICOMs, and will automatically replace an invalid pixel array with a valid one if necessary.