### PR TITLE
Support modality assignment by RecordHelper

### DIFF
--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -86,12 +86,10 @@ class RecordCreator:
     def __init__(
         self,
         functions: Optional[Iterable[str]] = None,
-        helpers: Optional[Iterable[str]] = [],
-        modality: Optional[str] = None,
+        helpers: Iterable[str] = [],
     ):
         self.functions = RECORD_REGISTRY.available_keys() if functions is None else functions
         self.helpers = [cast(Type[RecordHelper], HELPER_REGISTRY.get(h))() for h in helpers]
-        self.modality = modality
 
     def __call__(self, path: Path) -> FileRecord:
         result = FileRecord.from_file(path)
@@ -102,11 +100,10 @@ class RecordCreator:
                 # As such, open `dcm` once with all tags present and reuse it
                 if issubclass(dtype, DicomFileRecord):
                     if dcm is None:
-                        dcm = dtype.read(path, specific_tags=None)
+                        dcm = dtype.read(path, specific_tags=None, helpers=self.helpers)
                     result = dtype.from_dicom(
                         path,
                         dcm,
-                        modality=self.modality,
                     )
                 else:
                     result = dtype.from_file(path)

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -860,7 +860,7 @@ class SpotCompressionHelper(DirectoryHelper):
 @HELPER_REGISTRY(name="modality")
 @dataclass
 class ModalityHelper(RecordHelper):
-    r"""Helper to correc the modality of DICOM object. Some mammograms have a modality other than MG,
+    r"""Helper to correct the modality of DICOM object. Some mammograms have a modality other than MG,
     which results in a record other than :class:`MammogramFileRecord` being used.
     """
     force: bool = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 -e .
-git+https://github.com/TidalPaladin/callable-registry

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ def install(version):
         packages=find_packages(),
         install_requires=[
             "dicom-anonymizer @ git+https://github.com/medcognetics/dicom-anonymizer.git@v1.0.7-fork",
+            "registry @ git+https://github.com/TidalPaladin/callable-registry.git#f46de0",
             "colorama",
             "matplotlib",
             "pydicom",


### PR DESCRIPTION
The existing method for applying modality overrides is very rigid, requiring a manual override value to be provided. For easy organization of large datasets, it makes sense to support modality overrides in a more automated way based on other DICOM fields. 

This PR solves the above through the following changes:
* Adds additional method hook `on_read` to `RecordHelper`, which can transform the raw object read by a `FileRecord`. Previously `RecordHelper` only provided a hook for transforming a `FileRecord`. However, since fields like modality are used to determine the type of `FileRecord` that is created, the necessary override must take place before `FileRecord` creation.
* Adds a `ModalityHelper` which infers a modality based on other DICOM fields.