### PR TITLE
Fix/multiprocessing

### DIFF
--- a/dicom_utils/container/__init__.py
+++ b/dicom_utils/container/__init__.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .collection import FILTER_REGISTRY, RecordCollection, RecordCreator, RecordFilter, record_iterator
+from .collection import (
+    FILTER_REGISTRY,
+    ConcurrentMapper,
+    RecordCollection,
+    RecordCreator,
+    RecordFilter,
+    record_iterator,
+)
 from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID, TransferSyntaxUID
 from .record import (
     HELPER_REGISTRY,
@@ -35,4 +42,5 @@ __all__ = [
     "RecordHelper",
     "FILTER_REGISTRY",
     "RecordFilter",
+    "ConcurrentMapper",
 ]

--- a/dicom_utils/container/__init__.py
+++ b/dicom_utils/container/__init__.py
@@ -1,14 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .collection import (
-    FILTER_REGISTRY,
-    ConcurrentMapper,
-    RecordCollection,
-    RecordCreator,
-    RecordFilter,
-    record_iterator,
-)
+from .collection import FILTER_REGISTRY, RecordCollection, RecordCreator, RecordFilter, record_iterator
 from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID, TransferSyntaxUID
 from .record import (
     HELPER_REGISTRY,
@@ -22,9 +15,6 @@ from .record import (
 
 
 __all__ = [
-    "Series",
-    "Study",
-    "SeriesContainer",
     "SeriesUID",
     "StudyUID",
     "record_iterator",
@@ -42,5 +32,4 @@ __all__ = [
     "RecordHelper",
     "FILTER_REGISTRY",
     "RecordFilter",
-    "ConcurrentMapper",
 ]

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import itertools
 import json
 import logging
-import time
-from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from os import PathLike
 from pathlib import Path
@@ -29,7 +26,7 @@ from typing import (
 )
 
 from registry import RegisteredFunction, Registry
-from tqdm import tqdm
+from tqdm_multiprocessing import ConcurrentMapper
 
 from ..dicom import Dicom
 
@@ -236,191 +233,6 @@ def record_iterator(
 A = TypeVar("A")
 T = TypeVar("T", bound=Hashable)
 C = TypeVar("C", bound="RecordCollection")
-PoolExecutor = Union[ProcessPoolExecutor, ThreadPoolExecutor]
-
-
-@dataclass
-class ConcurrentMapper:
-    r"""Helper for mapping a function over an iterable using multiprocessing with tqdm support.
-
-    Args:
-        threads:
-            If ``True``, use :class:`ThreadPoolExecutor`, otherwise use :class:`ProcessPoolExecutor`
-
-        jobs:
-            Number of worker threads/processes to use
-
-        ignore_exceptions:
-            If ``True``, ignore exceptions that are raised when mapping over an iterable.
-
-        chunksize:
-            Chunk size for jobs that are submitted to the pool. See :class:`ProcessPoolExecutor` documentation
-            for more info.
-
-        timeout:
-            Timeout in seconds for tasks
-
-        exception_callback:
-            Optional callback to be called if a worker encounters an exception
-
-    Examples::
-
-        >>> iterable = list(range(5))
-        >>> func = lambda x, y: x+y
-        >>> with ConcurrentMapper() as mapper:
-        >>>     mapper.create_bar(desc="Processing", total=len(iterable))
-        >>>     result = mapper(func, iterable, y=1)
-        >>> print(result)
-        [1, 2, 3, 4, 5]
-    """
-    threads: bool = False
-    jobs: Optional[int] = None
-    ignore_exceptions: bool = False
-    chunksize: int = 1
-    timeout: Optional[float] = None
-    exception_callback: Optional[Callable[[Future], Any]] = None
-    preserve_order: bool = True
-
-    _pool: Optional[PoolExecutor] = field(init=False, repr=False, default=None)
-    _bar: Optional[tqdm] = field(init=False, repr=False, default=None)
-
-    def __post_init__(self):
-        if self.chunksize < 1:
-            raise ValueError("chunksize must be >= 1.")
-
-    def __enter__(self) -> "ConcurrentMapper":
-        self._pool = self.pool_type(self.jobs)
-        return self
-
-    def create_bar(self, *args, **kwargs) -> None:
-        r"""Create a tqdm progress bar. Args are forwarded to the tqdm bar."""
-        self._bar = tqdm(*args, **kwargs)
-
-    def close_bar(self):
-        if self._bar is not None:
-            self._bar.close()
-        self._bar = None
-
-    def __call__(self, fn: Callable[..., A], iterable: Iterable, *args, **kwargs) -> Iterator[A]:
-        if self._pool is None:
-            raise RuntimeError("Pool not initialized. Please use `with ConcurrentMapper() as mapper` to init a pool.")
-
-        chunks = self._get_chunks(iterable, chunksize=self.chunksize)
-        results = self._map(
-            partial(self._process_chunk, fn),
-            chunks,
-            *args,
-            **kwargs,
-        )
-        return self._chain_from_iterable_of_lists(results)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        assert self._pool is not None
-        self._pool.shutdown(wait=True)
-        self.close_bar()
-
-    def _force_kill_processes(self) -> None:
-        r"""Without this method, KeyboardInterrupt doesn't seem to kill worker processes"""
-        if isinstance(self._pool, ProcessPoolExecutor):
-            for pid, proc in self._pool._processes.items():  # type: ignore
-                logger.debug(f"Terminating PID {pid}")
-                proc.terminate()
-
-    @property
-    def pool_type(self) -> Type[PoolExecutor]:
-        return ThreadPoolExecutor if self.threads else ProcessPoolExecutor
-
-    @classmethod
-    def _update_bar(cls, bar: Optional[tqdm], future: Future) -> None:
-        if bar is not None:
-            result = future.result()
-            bar.update(len(result))
-
-    def _map(self, fn: Callable[..., A], iterable: Iterable, *args, **kwargs) -> Iterator[A]:
-        if self.timeout is not None:
-            end_time = self.timeout + time.monotonic()
-
-        assert self._pool is not None
-        fs: List[Future] = []
-        logger.debug("Submitting tasks")
-        for i in iterable:
-            f = self._pool.submit(fn, i, *args, **kwargs)
-            if self._bar is not None:
-                f.add_done_callback(lambda _f: self._update_bar(self._bar, _f))
-            fs.append(f)
-        logger.debug(f"Submitted {len(fs)} tasks")
-
-        # Yield must be hidden in closure so that the futures are submitted
-        # before the first iterator value is required.
-        def result_iterator():
-            try:
-                # reverse to keep finishing order
-                fs.reverse()
-                while fs:
-                    future = fs.pop()
-                    try:
-                        # Careful not to keep a reference to the popped future
-                        if self.timeout is None:
-                            yield self._result_or_cancel(future)
-                        else:
-                            yield self._result_or_cancel(future, end_time - time.monotonic())
-                    except (KeyboardInterrupt, SystemExit) as ex:
-                        logger.debug(f"Caught {type(ex)}, terminating processes")
-                        self._force_kill_processes()
-                        raise
-                    except Exception as ex:
-                        if self.exception_callback is not None:
-                            self.exception_callback(future)
-                        if self.ignore_exceptions:
-                            logger.info(f"Ignored exception {ex} for {future}")
-                        else:
-                            raise
-            finally:
-                for future in fs:
-                    future.cancel()
-
-        return cast(Iterator, result_iterator())
-
-    def _result_or_cancel(self, fut: Future, timeout: Optional[float] = None):
-        try:
-            try:
-                return fut.result(timeout)
-            finally:
-                fut.cancel()
-        finally:
-            # Break a reference cycle with the exception in self._exception
-            del fut
-
-    @classmethod
-    def _get_chunks(cls, iterable: Iterable[T], chunksize: int) -> Iterator[Iterable[T]]:
-        """Iterates over zip()ed iterables in chunks."""
-        it = iter(iterable)
-        while True:
-            chunk = tuple(itertools.islice(it, chunksize))
-            if not chunk:
-                return
-            yield chunk
-
-    @classmethod
-    def _process_chunk(cls, fn, chunk, *args, **kwargs):
-        """Processes a chunk of an iterable passed to map.
-        Runs the function passed to map() on a chunk of the
-        iterable passed to map.
-        This function is run in a separate process.
-        """
-        return [fn(c, *args, **kwargs) for c in chunk]
-
-    @classmethod
-    def _chain_from_iterable_of_lists(cls, iterable: Iterable[List[A]]) -> Iterator[A]:
-        """
-        Specialized implementation of itertools.chain.from_iterable.
-        Each item in *iterable* should be a list.  This function is
-        careful not to keep references to yielded objects.
-        """
-        for element in iterable:
-            element.reverse()
-            while element:
-                yield element.pop()
 
 
 def search_dir(path: PathLike, pattern: str) -> Iterable[Path]:

--- a/dicom_utils/container/input.py
+++ b/dicom_utils/container/input.py
@@ -186,6 +186,9 @@ class Input:
     def group_fn(self) -> Callable[[FileRecord], Hashable]:
         return cast(Callable[[FileRecord], Hashable], self.groups[0])
 
+    def __len__(self) -> int:
+        return len(self.cases)
+
     def __iter__(self) -> Iterator[Tuple[Tuple[str, ...], RecordCollection]]:
         r"""Iterates over pairs of named groups and the :class:`RecordCollection` containing that group."""
         for k, v in self.cases.items():

--- a/dicom_utils/container/output.py
+++ b/dicom_utils/container/output.py
@@ -3,7 +3,7 @@
 
 import json
 import re
-from abc import ABC, abstractmethod
+from abc import ABC, abstractclassmethod
 from functools import partial
 from os import PathLike
 from pathlib import Path
@@ -13,7 +13,7 @@ from registry import Registry
 from tqdm import tqdm
 
 from ..types import MammogramType
-from .collection import RecordCollection
+from .collection import ConcurrentMapper, RecordCollection
 from .input import Input
 from .record import FileRecord, MammogramFileRecord
 
@@ -44,41 +44,71 @@ class Output(ABC):
         record_filter: Optional[Callable[[FileRecord], bool]] = None,
         collection_filter: Optional[Callable[[RecordCollection], bool]] = None,
         use_bar: bool = True,
+        threads: bool = False,
+        jobs: Optional[int] = None,
     ):
         self.path = Path(path)
         self.path.mkdir(exist_ok=True, parents=True)
         self.record_filter = record_filter
         self.collection_filter = collection_filter
         self.use_bar = use_bar
+        self.threads = threads
+        self.jobs = jobs
 
     def __call__(self, inp: Union[Input, Dict[Tuple[str, ...], RecordCollection]]) -> Dict[str, RecordCollection]:
         result: Dict[str, RecordCollection] = {}
-        bar = self.tqdm(inp if isinstance(inp, Input) else inp.items())
-        for key, collection in bar:
-            name = str(Path(*key))
-            if self.collection_filter is not None and not self.collection_filter(collection):
-                continue
-            if self.record_filter is not None:
-                collection = collection.filter(self.record_filter)
-            dest = Path(self.path, name)
-            dest.mkdir(exist_ok=True, parents=True)
-            written = self.write(collection, dest)
-            result[name] = written
-            if isinstance(inp, Input):
-                key = inp.group_fn(next(iter(collection)))
-                self.write_metadata(name, key, collection, dest)
+        iterable = inp if isinstance(inp, Input) else inp.items()
+        with ConcurrentMapper(self.threads, self.jobs, chunksize=8) as mapper:
+            mapper.create_bar(total=len(iterable), desc=f"Writing {self.__class__.__name__}")
+            it = mapper(
+                self._process,
+                iterable,
+                path=self.path,
+                record_filter=self.record_filter,
+                collection_filter=self.collection_filter,
+                group_fn=inp.group_fn if isinstance(inp, Input) else None,
+            )
+            for item in it:
+                if item is not None:
+                    name, written = item
+                    result[name] = written
         return result
+
+    @classmethod
+    def _process(
+        cls,
+        kc,
+        path: Path,
+        record_filter: Optional[Callable[[FileRecord], bool]] = None,
+        collection_filter: Optional[Callable[[RecordCollection], bool]] = None,
+        group_fn: Optional[Callable] = None,
+    ):
+        key, collection = kc
+        name = str(Path(*key))
+        if collection_filter is not None and not collection_filter(collection):
+            return
+        if record_filter is not None:
+            collection = collection.filter(record_filter)
+        dest = Path(path, name)
+        dest.mkdir(exist_ok=True, parents=True)
+        # pyright fails to recognize this is an abstract classmethod
+        written = cls.write(collection, dest)  # type: ignore
+        if group_fn is not None:
+            key = group_fn(next(iter(collection)))
+            cls.write_metadata(name, key, collection, dest)
+        return name, written
 
     @property
     def tqdm(self) -> Callable:
         return partial(tqdm, leave=False, disable=not self.use_bar)
 
-    @abstractmethod
-    def write(self, collection: RecordCollection, dest: Path) -> RecordCollection:
+    @abstractclassmethod
+    def write(cls, collection: RecordCollection, dest: Path) -> RecordCollection:
         ...
 
+    @classmethod
     def write_metadata(
-        self,
+        cls,
         name: str,
         key: Hashable,
         collection: RecordCollection,
@@ -90,11 +120,12 @@ class Output(ABC):
         metadata["group"] = key
         metadata["name"] = name
         with open(path, "w") as f:
-            json.dump(metadata, f, sort_keys=True, indent=indent, default=lambda o: str(o))
+            json.dump(metadata, f, sort_keys=True, indent=indent, default=str)
 
 
 class SymlinkFileOutput(Output):
-    def write(self, collection: RecordCollection, dest: Path) -> RecordCollection:
+    @classmethod
+    def write(cls, collection: RecordCollection, dest: Path) -> RecordCollection:
         assert dest.is_dir()
         result = RecordCollection()
         for name, rec in collection.standardized_filenames():

--- a/dicom_utils/container/output.py
+++ b/dicom_utils/container/output.py
@@ -11,9 +11,10 @@ from typing import Callable, Dict, Final, Hashable, Iterable, List, Optional, Se
 
 from registry import Registry
 from tqdm import tqdm
+from tqdm_multiprocessing import ConcurrentMapper
 
 from ..types import MammogramType
-from .collection import ConcurrentMapper, RecordCollection
+from .collection import RecordCollection
 from .input import Input
 from .record import FileRecord, MammogramFileRecord
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ def install(version):
         install_requires=[
             "dicom-anonymizer @ git+https://github.com/medcognetics/dicom-anonymizer.git@v1.0.7-fork",
             "registry @ git+https://github.com/TidalPaladin/callable-registry.git#f46de0",
+            "tqdm_multiprocessing @ git+https://github.com/TidalPaladin/tqdm-multiprocessing.git#6119929",
             "colorama",
             "matplotlib",
             "pydicom",

--- a/tests/test_container/test_collection.py
+++ b/tests/test_container/test_collection.py
@@ -11,7 +11,6 @@ import pytest
 from dicom_utils.container import (
     FILTER_REGISTRY,
     HELPER_REGISTRY,
-    ConcurrentMapper,
     DicomFileRecord,
     DicomImageFileRecord,
     FileRecord,
@@ -34,82 +33,6 @@ def dicom_files(tmp_path, dicom_file):
             shutil.copy(dicom_file, str(dest))
             paths.append(dest)
     return paths
-
-
-class TestConcurrentMapper:
-    @pytest.mark.parametrize("jobs", [1, 4, None])
-    @pytest.mark.parametrize("threads", [True, False])
-    @pytest.mark.parametrize("length", [10, 1000])
-    @pytest.mark.parametrize("chunksize", [1, 32])
-    @pytest.mark.parametrize("inp_type", [list, set, iter])
-    def test_map_list(self, threads, jobs, length, chunksize, inp_type):
-        inp = list(range(length))
-        exp = [str(x) for x in inp]
-        inp = inp_type(inp)
-        with ConcurrentMapper(threads=threads, jobs=jobs, chunksize=chunksize) as mapper:
-            mapper.create_bar(desc="Processing", total=length)
-            result = list(mapper(str, inp))
-        assert result == exp
-
-    @pytest.mark.parametrize("threads", [True, False])
-    def test_forward_args(self, threads):
-        inp = list(range(10))
-        exp = [x + 2 for x in inp]
-        with ConcurrentMapper(threads=threads, jobs=2, chunksize=2) as mapper:
-            result = list(mapper(TestConcurrentMapper._add, inp, y=2))
-        assert result == exp
-
-    @staticmethod
-    def _add(x: int, y: int):
-        # NOTE: these must be pickleable methods
-        return x + y
-
-    @pytest.mark.parametrize(
-        "ignore",
-        [
-            pytest.param(False, marks=pytest.mark.xfail(raises=ValueError)),
-            True,
-        ],
-    )
-    def test_ignore_exceptions(self, ignore):
-        inp = list(range(1000))
-        with ConcurrentMapper(jobs=2, chunksize=2, ignore_exceptions=ignore) as mapper:
-            list(mapper(TestConcurrentMapper._raise, inp))
-
-    @staticmethod
-    def _raise(x):
-        raise ValueError()
-
-    @pytest.mark.parametrize("ignore", [False, True])
-    def test_exception_callback(self, mocker, ignore):
-        inp = list(range(1000))
-        spy = mocker.spy(TestConcurrentMapper, "_callback")
-        with ConcurrentMapper(jobs=2, chunksize=2, ignore_exceptions=ignore, exception_callback=spy) as mapper:
-            try:
-                list(mapper(TestConcurrentMapper._raise, inp))
-            except ValueError:
-                pass
-            spy.assert_called()
-
-    @staticmethod
-    def _callback(f):
-        pass
-
-    @pytest.mark.parametrize("ex_type", [KeyboardInterrupt, SystemExit])
-    def test_interrupt(self, ex_type):
-        inp = list(range(4))
-        with ConcurrentMapper(jobs=4, chunksize=2) as mapper:
-            try:
-                list(mapper(TestConcurrentMapper._loop, inp, ex_type=ex_type))
-            except ex_type:
-                pass
-
-    @staticmethod
-    def _loop(x, ex_type):
-        if x == 0:
-            raise ex_type()
-        while True:
-            pass
 
 
 class TestRecordCreator:


### PR DESCRIPTION
Optimized and robust multiprocessing support is needed order to scale the FileRecord / data organization pipeline to larger volumes of inputs. This PR transitions the existing multiprocessing logic over to a new [library](https://github.com/TidalPaladin/tqdm-multiprocessing), which is well tested and optimized for responsive tqdm progress bars and a large number of multiprocessing tasks. Other minor adjustments are made to eliminate deadlocks and ensure that methods involved in multiprocessing can be pickled.