### PR TITLE
Improve data organization support

### DIFF
--- a/dicom_utils/container/__init__.py
+++ b/dicom_utils/container/__init__.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 from .collection import FILTER_REGISTRY, RecordCollection, RecordCreator, RecordFilter, record_iterator
 from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID, TransferSyntaxUID
+from .protocols import (
+    SupportsGenerated,
+    SupportsManufacturer,
+    SupportsPatientID,
+    SupportsStudyDate,
+    SupportsStudyID,
+    SupportsUID,
+)
 from .record import (
     HELPER_REGISTRY,
     RECORD_REGISTRY,
@@ -11,6 +18,7 @@ from .record import (
     FileRecord,
     MammogramFileRecord,
     RecordHelper,
+    StandardizedFilename,
 )
 
 
@@ -32,4 +40,12 @@ __all__ = [
     "RecordHelper",
     "FILTER_REGISTRY",
     "RecordFilter",
+    "StandardizedFilename",
+    "SupportsGenerated",
+    "SupportsManufacturer",
+    "SupportsPatientID",
+    "SupportsStudyDate",
+    "SupportsStudyID",
+    "SupportsUID",
+    "SupportsStudyID",
 ]

--- a/dicom_utils/container/group.py
+++ b/dicom_utils/container/group.py
@@ -2,16 +2,21 @@
 # -*- coding: utf-8 -*-
 
 
+import logging
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from typing import Callable, Hashable, Optional, TypeVar
+from typing import Callable, Dict, Hashable, Iterator, List, Optional, Sequence, Tuple, TypeVar, cast
 
 from registry import Registry
+from tqdm_multiprocessing import ConcurrentMapper
+
+from .collection import CollectionHelper, RecordCollection, apply_helpers
 
 # Type checking fails when dataclass attr name matches a type alias.
 # Import types under a different alias
 from .helpers import StudyUID
-from .record import FileRecord
+from .record import HELPER_REGISTRY, FileRecord
 
 
 H = TypeVar("H", bound=Hashable)
@@ -19,6 +24,10 @@ H = TypeVar("H", bound=Hashable)
 
 GroupFunction = Callable[[FileRecord], Hashable]
 GROUP_REGISTRY = Registry("group", bound=Callable[..., Hashable])
+Key = Tuple[Hashable, ...]
+GroupDict = Dict[Key, RecordCollection]
+
+logger = logging.getLogger(__name__)
 
 
 @GROUP_REGISTRY(name="study-uid")
@@ -43,3 +52,72 @@ def group_by_patient_id(rec: FileRecord) -> Optional[str]:
 @GROUP_REGISTRY(name="study-date")
 def group_by_study_date(rec: FileRecord) -> Optional[str]:
     return getattr(rec, "StudyDate", None)
+
+
+@dataclass
+class Grouper:
+    groups: Sequence[str]
+    helpers: Sequence[str]
+    threads: bool = False
+    jobs: Optional[int] = None
+    chunksize: int = 8
+    use_bar: bool = True
+
+    _group_fns: Sequence[GroupFunction] = field(init=False)
+    _helper_fns: Sequence[CollectionHelper] = field(init=False)
+
+    def __post_init__(self):
+        if not self.groups:
+            raise ValueError("`groups` cannot be empty")
+
+        self._group_fns = [GROUP_REGISTRY.get(g).instantiate_with_metadata().fn for g in self.groups]
+        self._helper_fns = list(self._build_collection_helpers())
+        logger.info(f"Collection helpers: {self._helper_fns}")
+
+    def _build_collection_helpers(self) -> Iterator[CollectionHelper]:
+        for h in self.helpers:
+            helper = HELPER_REGISTRY.get(h).instantiate_with_metadata().fn
+            # isolate CollectionHelpers
+            if isinstance(helper, CollectionHelper):
+                yield helper
+            else:
+                logger.debug(f"Ignoring non-RecordHelper `{h}` of type {type(h)}")
+
+    def __call__(self, collection: RecordCollection) -> Dict[Hashable, RecordCollection]:
+        start_len = len(collection)
+        result: Dict[Key, RecordCollection] = {tuple(): collection}
+
+        with ConcurrentMapper(self.threads, self.jobs, chunksize=self.chunksize) as mapper:
+            for i, group_fn in list(enumerate(self._group_fns)):
+                # run the group function
+                mapper.create_bar(
+                    desc=f"Running grouper {self.groups[i]}", disable=(not self.use_bar), leave=False, total=len(result)
+                )
+                mapped = mapper(self._group, list(result.items()), group_fn=group_fn)
+                result = {k: v for group_result in mapped for k, v in group_result}
+                mapper.close_bar()
+
+                # run helpers for this stage in the grouping process
+                mapper.create_bar(
+                    desc="Running group helpers", disable=(not self.use_bar), leave=False, total=len(result)
+                )
+                mapped = mapper(self._apply_helpers, list(result.items()), index=i)
+                result = {k: v for k, v in mapped}
+                mapper.close_bar()
+
+        end_len = sum(len(c) for c in result.values())
+        assert start_len == end_len, "A record was lost during grouping"
+        return cast(Dict[Hashable, RecordCollection], result)
+
+    @classmethod
+    def _group(cls, inp: Tuple[Key, RecordCollection], group_fn: GroupFunction) -> List[Tuple[Key, RecordCollection]]:
+        key, entry = inp
+        result: List[Tuple[Key, RecordCollection]] = []
+        for subkey, subgroup in entry.group_by(group_fn).items():
+            new_key = key + (subkey,)
+            result.append((new_key, subgroup))
+        return result
+
+    def _apply_helpers(self, inp: Tuple[Key, RecordCollection], index: int) -> Tuple[Key, RecordCollection]:
+        k, col = inp
+        return k, apply_helpers(col, self._helper_fns, index=index)

--- a/dicom_utils/container/protocols.py
+++ b/dicom_utils/container/protocols.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import logging
+import re
+from typing import Optional, Protocol, Union, cast, runtime_checkable
+
+from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID
+
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SupportsStudyUID(Protocol):
+    StudyInstanceUID: Optional[StudyUID] = None
+
+    def same_study_as(self, other: "SupportsStudyUID") -> bool:
+        r"""Checks if this record is part of the same study as record ``other``."""
+        return bool(self.StudyInstanceUID) and self.StudyInstanceUID == other.StudyInstanceUID
+
+
+@runtime_checkable
+class SupportsPatientID(Protocol):
+    PatientID: Optional[str] = None
+    PatientName: Optional[str] = None
+
+    def same_patient_as(self, other: "SupportsPatientID") -> bool:
+        r"""Checks if this record references the same patient as record ``other``."""
+        if self.PatientID:
+            return self.PatientID == other.PatientID
+        else:
+            return bool(self.PatientName) and self.PatientName == other.PatientName
+
+
+@runtime_checkable
+class SupportsStudyID(Protocol):
+    StudyID: Optional[str] = None
+
+
+@runtime_checkable
+class SupportsUID(Protocol):
+    SOPInstanceUID: Optional[SOPUID] = None
+    SeriesInstanceUID: Optional[SeriesUID] = None
+
+    @property
+    def has_uid(self) -> bool:
+        r"""Tests if the record has a SeriesInstanceUID or SOPInstanceUID"""
+        return bool(self.SeriesInstanceUID or self.SOPInstanceUID)
+
+    def same_uid_as(self, other: "SupportsUID") -> bool:
+        r"""Checks if this record is part of the same study as record ``other``."""
+        return bool(self.SOPInstanceUID) and bool(other.SOPInstanceUID) and self.SOPInstanceUID == other.SOPInstanceUID
+
+    def get_uid(self, prefer_sop: bool = True) -> ImageUID:
+        r"""Gets an image level UID. The UID will be chosen from SeriesInstanceUID and SOPInstanceUID,
+        with preference as specified in ``prefer_sop``.
+        """
+        if not self.has_uid:
+            raise AttributeError("DicomFileRecord has no UID")
+        if prefer_sop:
+            result = self.SOPInstanceUID or self.SeriesInstanceUID
+        else:
+            result = self.SeriesInstanceUID or self.SOPInstanceUID
+        assert result is not None
+        return result
+
+
+@runtime_checkable
+class SupportsStudyDate(Protocol):
+    StudyDate: Optional[str] = None
+
+    @property
+    def StudyYear(self) -> Optional[int]:
+        r"""Extracts a year from ``StudyDate``.
+
+        Returns:
+            First 4 digits of ``StudyDate`` as an int, or None if a year could not be parsed
+        """
+        if self.StudyDate and len(self.StudyDate) > 4:
+            try:
+                return int(self.StudyDate[:4])
+            except Exception:
+                pass
+        return None
+
+
+@runtime_checkable
+class SupportsGenerated(Protocol):
+    generated: bool
+
+
+@runtime_checkable
+class SupportsManufacturer(Protocol):
+    Manufacturer: Optional[str] = None
+    ManufacturerModelName: Optional[str] = None
+    ManufacturerModelNumber: Optional[str] = None
+
+    def search_manufacturer_info(self, pattern: Union[str, re.Pattern]) -> Optional[re.Match]:
+        pattern = pattern if isinstance(pattern, str) else cast(re.Pattern, re.compile(pattern))
+        assert isinstance(pattern, re.Pattern)
+        if self.Manufacturer and (m := pattern.search(self.Manufacturer)):
+            return m
+        elif self.ManufacturerModelName and (m := pattern.search(self.ManufacturerModelName)):
+            return m
+        elif self.ManufacturerModelNumber and (m := pattern.search(self.ManufacturerModelNumber)):
+            return m
+        return None

--- a/dicom_utils/dicom_factory.py
+++ b/dicom_utils/dicom_factory.py
@@ -17,8 +17,8 @@ from numpy.random import default_rng
 from pydicom import DataElement, Dataset, FileDataset, Sequence
 from pydicom.data import get_testdata_file
 from pydicom.valuerep import VR
+from registry import Registry
 
-from .container.record import Registry
 from .dicom import set_pixels
 from .tags import Tag
 
@@ -72,6 +72,11 @@ class BaseFactory(ABC):
         size = tuple(x for x in (channels, NumberOfFrames, Rows, Columns) if x > 1)
         rng = default_rng(seed)
         return rng.integers(low, high, size, dtype=np.uint16)
+
+    @classmethod
+    def random_uid(cls, length: int = 6, seed: int = 42) -> str:
+        rng = default_rng(seed)
+        return "".join(str(x) for x in rng.integers(0, 10, length))
 
     @classmethod
     def pixel_array_from_dicom(
@@ -286,8 +291,8 @@ class CompleteMammographyStudyFactory(ConcatFactory):
                 "ViewPosition": view,
                 "BreastImplantPresent": "YES" if implant else "NO",
                 "ViewModifierCodeSequence": codes,
-                "SOPInstanceUID": f"sop-{i}",
-                "SeriesInstanceUID": f"series-{i}",
+                "SOPInstanceUID": f"sop-{self.random_uid(seed=seed)}-{i}",
+                "SeriesInstanceUID": f"series-{self.random_uid(seed=seed)}-{i}",
             }
             factory = cast(Type[DicomFactory], FACTORY_REGISTRY.get(mtype))(
                 proto=proto,

--- a/dicom_utils/dicom_factory.py
+++ b/dicom_utils/dicom_factory.py
@@ -291,8 +291,8 @@ class CompleteMammographyStudyFactory(ConcatFactory):
                 "ViewPosition": view,
                 "BreastImplantPresent": "YES" if implant else "NO",
                 "ViewModifierCodeSequence": codes,
-                "SOPInstanceUID": f"sop-{self.random_uid(seed=seed)}-{i}",
-                "SeriesInstanceUID": f"series-{self.random_uid(seed=seed)}-{i}",
+                "SOPInstanceUID": f"sop-{self.random_uid(seed=seed+i)}-{i}",
+                "SeriesInstanceUID": f"series-{self.random_uid(seed=seed+i)}-{i}",
             }
             factory = cast(Type[DicomFactory], FACTORY_REGISTRY.get(mtype))(
                 proto=proto,

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -4,7 +4,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Dict, Final, Iterable, Iterator, List, NamedTuple, Optional, TypeVar, cast
+from typing import Any, Dict, Final, Iterable, Iterator, List, NamedTuple, Optional, TypeVar, Union, cast
 
 from pydicom import DataElement
 from pydicom.dataset import Dataset
@@ -341,13 +341,18 @@ class Laterality(EnumMixin):
             return cls.UNKNOWN
 
     @classmethod
-    def from_patient_orientation(cls, value: List[str]) -> "Laterality":
+    def from_patient_orientation(cls, value: Union[str, List[str]]) -> "Laterality":
+        if isinstance(value, str):
+            return cls.from_str(value)
+
         for item in value:
             parts = set(str(item))
             if "L" in parts:
                 return cls.RIGHT
             elif "R" in parts:
                 return cls.LEFT
+            elif result := cls.from_str(item):
+                return result
         return cls.UNKNOWN
 
     @classmethod
@@ -458,12 +463,17 @@ class ViewPosition(EnumMixin):
         return cls.UNKNOWN
 
     @classmethod
-    def from_patient_orientation(cls, value: List[str]) -> "ViewPosition":
+    def from_patient_orientation(cls, value: Union[str, List[str]]) -> "ViewPosition":
+        if isinstance(value, str):
+            return cls.from_str(value)
+
         for item in value:
             if item in ("FL", "FR"):
                 return cls.MLO
             elif item in ("R", "L"):
                 return cls.CC
+            elif result := cls.from_str(item):
+                return result
         return cls.UNKNOWN
 
     @classmethod

--- a/tests/test_container/test_input.py
+++ b/tests/test_container/test_input.py
@@ -28,5 +28,5 @@ class TestInput:
         assert len(p) == 1
         key = p[0][0]
         assert isinstance(key, tuple)
-        assert len(key) == 3
+        assert len(key) == 2
         assert all(isinstance(k, str) for k in key)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -454,6 +454,8 @@ class TestViewPosition:
             (["P", "L"], ViewPosition.CC),
             (["P", "R"], ViewPosition.CC),
             (["P"], ViewPosition.UNKNOWN),
+            ("CC", ViewPosition.CC),
+            ("MLO", ViewPosition.MLO),
             ([], ViewPosition.UNKNOWN),
         ],
     )


### PR DESCRIPTION
Implements changes to streamline the data organization process.

Includes the following changes:
* Adopt default organization scheme of `Patient/Study`
* Add `CollectionHelper` for helpers that need to run on an aggregated group of files
* Add `Grouper` class with support for running `CollectionHelper`s at each stage of grouping
* Support accessing other namers in `StudyIDNamer`
* Add additional fields to Dicom related records
* Add `StandardizedFilename` class to streamline output file naming
* Move protocols to separate file
* Ensure factory for complete cases will produce unique SOPInstanceUIDs