### PR TITLE
Add Laterality.reduce helper

### DIFF
--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -387,6 +387,37 @@ class Laterality(EnumMixin):
             return "r"
         return ""
 
+    def reduce(self, other: "Laterality") -> "Laterality":
+        r"""Reduces two :class:`Laterality` inputs according to the following rules:
+        * ANY + BILATERAL -> BILATERAL
+        * LEFT + RIGHT -> BILATERAL
+        * LEFT + (UNKNOWN/NONE) -> LEFT
+        * RIGHT + (UNKNOWN/NONE) -> RIGHT
+        * NONE + NONE -> NONE
+        * UNKOWN + UNKOWN -> UNKNOWN
+        """
+        # either input is unknown, fall back to __add__
+        if self.is_unknown or other.is_unknown:
+            return self + other
+
+        # if either input is bilateral, output should be bilateral
+        elif self == Laterality.BILATERAL or other == Laterality.BILATERAL:
+            return Laterality.BILATERAL
+
+        # if both inputs are unilateral complements, reduce to bilateral
+        # if either inputs is a unilateral non-complements, return the unilateral laterality
+        elif self.is_unilateral or other.is_unilateral:
+            return (
+                Laterality.BILATERAL
+                if self.is_unilateral and other.is_unilateral and self != other
+                else self
+                if self.is_unilateral
+                else other
+            )
+
+        # only remaining possibility
+        return Laterality.NONE
+
 
 CC_STRINGS: Final = {"cranio-caudal", "caudal-cranial"}
 ML_STRINGS: Final = {"medio-lateral", "medial-lateral"}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -274,6 +274,22 @@ class TestLaterality:
         assert orient.is_unilateral == expected
 
     @pytest.mark.parametrize(
+        "l1,l2,expected",
+        [
+            (Laterality.RIGHT, Laterality.BILATERAL, Laterality.BILATERAL),
+            (Laterality.LEFT, Laterality.RIGHT, Laterality.BILATERAL),
+            (Laterality.RIGHT, Laterality.LEFT, Laterality.BILATERAL),
+            (Laterality.LEFT, Laterality.LEFT, Laterality.LEFT),
+            (Laterality.RIGHT, Laterality.NONE, Laterality.RIGHT),
+            (Laterality.NONE, Laterality.NONE, Laterality.NONE),
+            (Laterality.UNKNOWN, Laterality.NONE, Laterality.NONE),
+            (Laterality.BILATERAL, Laterality.UNKNOWN, Laterality.BILATERAL),
+        ],
+    )
+    def test_reduce(self, l1, l2, expected):
+        assert l1.reduce(l2) == expected
+
+    @pytest.mark.parametrize(
         "string,expected",
         [
             ("rcc", Laterality.RIGHT),


### PR DESCRIPTION
Adds a helper for reducing `Laterality` instances beyond the default `__add__` implementation. The `reduce` method implements a special case reduction that allows left/right/bilateral lateralities to overwrite the `NONE` laterality, and allows for reducing left + right lateralities to bilateral.