### PR TITLE
Make additional changes for data organization

### DIFF
--- a/dicom_utils/container/group.py
+++ b/dicom_utils/container/group.py
@@ -3,6 +3,7 @@
 
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
@@ -105,8 +106,12 @@ class Grouper:
                 result = {k: v for k, v in mapped}
                 mapper.close_bar()
 
-        end_len = sum(len(c) for c in result.values())
-        assert start_len == end_len, "A record was lost during grouping"
+        end_len = sum(len(collection) for collection in result.values())
+        if start_len != end_len:
+            warnings.warn(
+                "Grouping began with {start_len} records and ended with {end_len} records. "
+                "This may be expected behavior depending on what helpers are being used."
+            )
         return cast(Dict[Hashable, RecordCollection], result)
 
     @classmethod

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -72,7 +72,15 @@ from ..types import PhotometricInterpretation as PI
 from ..types import ViewPosition, get_value, iterate_view_modifier_codes
 from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID
 from .helpers import TransferSyntaxUID as TSUID
-from .protocols import SupportsManufacturer, SupportsPatientID, SupportsStudyDate, SupportsStudyUID, SupportsUID
+from .protocols import (
+    SupportsGenerated,
+    SupportsManufacturer,
+    SupportsPatientAge,
+    SupportsPatientID,
+    SupportsStudyDate,
+    SupportsStudyUID,
+    SupportsUID,
+)
 
 
 STANDARD_MAMMO_VIEWS: Final[Set[MammogramView]] = {
@@ -103,7 +111,11 @@ class StandardizedFilename(PosixPath):
 
     @property
     def prefix(self) -> str:
-        return SEP.join(self.tokenize()[:FILE_ID_IDX])
+        return SEP.join(self.prefix_parts)
+
+    @property
+    def prefix_parts(self) -> List[str]:
+        return self.tokenize()[:FILE_ID_IDX]
 
     @property
     def file_id(self) -> str:
@@ -323,7 +335,16 @@ class FileRecord:
 
 @RECORD_REGISTRY(name="dicom", suffixes=[".dcm"])
 @dataclass(frozen=True, order=False, eq=False)
-class DicomFileRecord(FileRecord, SupportsStudyUID, SupportsStudyDate, SupportsManufacturer, SupportsUID):
+class DicomFileRecord(
+    FileRecord,
+    SupportsStudyUID,
+    SupportsStudyDate,
+    SupportsManufacturer,
+    SupportsUID,
+    SupportsPatientID,
+    SupportsPatientAge,
+    SupportsGenerated,
+):
     r"""Data structure for storing critical information about a DICOM file.
     File IO operations on DICOMs can be expensive, so this class collects all
     required information in a single pass to avoid repeated file opening.
@@ -337,6 +358,8 @@ class DicomFileRecord(FileRecord, SupportsStudyUID, SupportsStudyDate, SupportsM
     BodyPartExamined: Optional[str] = None
     PatientOrientation: Optional[List[str]] = None
     StudyDate: Optional[str] = None
+    ContentDate: Optional[str] = None
+    AcquisitionDate: Optional[str] = None
     SeriesDescription: Optional[str] = None
     StudyDescription: Optional[str] = None
     PatientName: Optional[str] = None
@@ -347,7 +370,11 @@ class DicomFileRecord(FileRecord, SupportsStudyUID, SupportsStudyDate, SupportsM
     ManufacturerModelNumber: Optional[str] = None
     PresentationIntentType: Optional[str] = None
     PatientAge: Optional[str] = None
+    PatientBirthDate: Optional[str] = None
     BodyPartThickness: Optional[str] = None
+
+    generated: bool = False
+    is_cad: bool = False
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, type(self)):
@@ -419,6 +446,8 @@ class DicomFileRecord(FileRecord, SupportsStudyUID, SupportsStudyDate, SupportsM
         result["secondary_capture"] = self.is_secondary_capture
         result["diagnostic"] = self.is_diagnostic
         result["screening"] = self.is_screening
+        result["is_cad"] = self.is_cad
+        result["generated"] = self.generated
         return result
 
     @classmethod
@@ -519,6 +548,8 @@ class DicomFileRecord(FileRecord, SupportsStudyUID, SupportsStudyDate, SupportsM
             path = path.add_modifier("secondary")
         if self.is_for_processing:
             path = path.add_modifier("proc")
+        if self.is_cad:
+            path = path.add_modifier("cad")
         return path
 
     @classmethod
@@ -689,6 +720,7 @@ class MammogramFileRecord(DicomImageFileRecord):
             and not self.is_magnified
             and not self.is_secondary_capture
             and not self.is_for_processing
+            and not self.is_cad
         )
 
     @property
@@ -697,11 +729,10 @@ class MammogramFileRecord(DicomImageFileRecord):
 
     @classmethod
     def is_complete_mammo_case(cls, records: Iterable["MammogramFileRecord"]) -> bool:
-        study_uid: Optional[StudyUID] = None
         needed_views: Dict[MammogramView, Optional[MammogramFileRecord]] = {k: None for k in STANDARD_MAMMO_VIEWS}
         for rec in records:
-            # don't consider secondary captures
-            if not isinstance(rec, MammogramFileRecord) or rec.is_secondary_capture:
+            # only consider standard views
+            if not isinstance(rec, MammogramFileRecord) or not rec.is_standard_mammo_view:
                 continue
             key = rec.mammogram_view
             if key in needed_views:
@@ -744,7 +775,8 @@ class MammogramFileRecord(DicomImageFileRecord):
 
         # modifiers
         # TODO make this a loop/lookup
-        modifiers: List[str] = []
+        path = super().standardized_filename(file_id)
+        modifiers: List[str] = path.prefix_parts[1:]
         if self.is_spot_compression:
             modifiers.append("spot")
         if self.is_magnified:
@@ -764,7 +796,7 @@ class MammogramFileRecord(DicomImageFileRecord):
 
         prefix = [filetype, view, *modifiers]
         prefix = [p for p in prefix if p]
-        path = super().standardized_filename(file_id).with_prefix(*prefix)
+        path = path.with_prefix(*prefix)
         return path.with_suffix(".dcm")
 
     @classmethod

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -592,10 +592,9 @@ class PixelSpacing:
         raise ValueError(f"Failed to parse PixelSpacing from {string}")
 
     @classmethod
-    def from_dicom(cls, dcm: Dicom) -> "PixelSpacing":
-        for tag in cls.get_required_tags():
+    def from_tags(cls, tags: Dict[Tag, Any]) -> "PixelSpacing":
+        for tag, spacing in tags.items():
             try:
-                spacing = get_value(dcm, tag, None)
                 if isinstance(spacing, str):
                     return cls.from_str(spacing)
                 elif isinstance(spacing, MultiValue):
@@ -604,6 +603,10 @@ class PixelSpacing:
             except ValueError:
                 pass
         raise RuntimeError("Failed to create PixelSpacing from DICOM")
+
+    @classmethod
+    def from_dicom(cls, dcm: Dicom) -> "PixelSpacing":
+        return cls.from_tags({tag: value for tag, value in get_tag_values(cls.get_required_tags(), dcm).items()})
 
     @staticmethod
     def get_required_tags() -> List[Tag]:

--- a/tests/test_container/test_protocols.py
+++ b/tests/test_container/test_protocols.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from dicom_utils.container.protocols import SupportsManufacturer, SupportsPatientID, SupportsStudyUID, SupportsUID
+
+
+class TestSupportsStudyUID:
+    @pytest.fixture
+    def factory(self):
+        @dataclass
+        class Impl(SupportsStudyUID):
+            StudyInstanceUID: Optional[str] = None
+
+        return Impl
+
+    @pytest.mark.parametrize(
+        "uid1,uid2,exp",
+        [
+            pytest.param("1.2.3", "1.2.3", True),
+            pytest.param(None, "1.2.3", False),
+            pytest.param("1.2.3", None, False),
+        ],
+    )
+    def test_same_study_as(self, factory, uid1, uid2, exp):
+        s1 = factory(uid1)
+        s2 = factory(uid2)
+        assert s1.same_study_as(s2) == exp
+
+
+class TestSupportsPatientID:
+    @pytest.fixture
+    def factory(self):
+        @dataclass
+        class Impl(SupportsPatientID):
+            PatientID: Optional[str] = None
+            PatientName: Optional[str] = None
+
+        return Impl
+
+    @pytest.mark.parametrize(
+        "id1,name1,id2,name2,exp",
+        [
+            pytest.param("P1", None, "P1", None, True),
+            pytest.param("P1", None, "P2", None, False),
+            pytest.param("P1", None, None, None, False),
+            pytest.param(None, None, None, None, False),
+            pytest.param("P1", "John Doe", "P2", "John Doe", False),
+            pytest.param("P1", "John A. Doe", "P1", "John Alex Doe", True),
+        ],
+    )
+    def test_same_patient_as(self, factory, id1, name1, id2, name2, exp):
+        s1 = factory(id1, name1)
+        s2 = factory(id2, name2)
+        assert s1.same_patient_as(s2) == exp
+
+
+class TestSupportsUID:
+    @pytest.fixture
+    def factory(self):
+        @dataclass
+        class Impl(SupportsUID):
+            SOPInstanceUID: Optional[str] = None
+            SeriesInstanceUID: Optional[str] = None
+
+        return Impl
+
+    @pytest.mark.parametrize(
+        "sop,series,prefer_sop,exp",
+        [
+            pytest.param("1.2.3", None, True, "1.2.3"),
+            pytest.param(None, "1.2.3", True, "1.2.3"),
+            pytest.param("1.2.3", "2.3.4", True, "1.2.3"),
+            pytest.param("1.2.3", "2.3.4", False, "2.3.4"),
+            pytest.param(None, None, True, None, marks=pytest.mark.xfail(raises=AttributeError)),
+        ],
+    )
+    def test_get_uid(self, factory, sop, series, prefer_sop, exp):
+        s = factory(sop, series)
+        assert s.get_uid(prefer_sop) == exp
+
+    @pytest.mark.parametrize(
+        "sop1,series1,sop2,series2,exp",
+        [
+            pytest.param("1.2.3", None, "1.2.3", None, True),
+            pytest.param("1.2.3", None, "2.3.4", None, False),
+            pytest.param("1.2.3", "1.2.3", "2.3.4", "1.2.3", False),
+            pytest.param(None, "1.2.3", None, "1.2.3", True),
+            pytest.param(None, None, None, None, False),
+        ],
+    )
+    def test_same_patient_as(self, factory, sop1, series1, sop2, series2, exp):
+        s1 = factory(sop1, series1)
+        s2 = factory(sop2, series2)
+        assert s1.same_uid_as(s2) == exp
+
+
+class TestSupportsManufacturer:
+    @pytest.fixture
+    def factory(self):
+        @dataclass
+        class Impl(SupportsManufacturer):
+            Manufacturer: Optional[str] = None
+            ManufacturerModelName: Optional[str] = None
+            ManufacturerModelNumber: Optional[str] = None
+
+        return Impl
+
+    @pytest.mark.parametrize(
+        "man,model,number,pattern,exp",
+        [
+            pytest.param(None, None, None, "foo", None),
+            pytest.param("man", "model", "number", "m.*", "man"),
+            pytest.param(None, "model", "number", "m.*", "model"),
+            pytest.param("foo", "bar", "model_num", "m.*", "model_num"),
+        ],
+    )
+    def test_search_manufacturer_info(self, factory, man, model, number, pattern, exp):
+        s = factory(man, model, number)
+        m = s.search_manufacturer_info(pattern)
+        if exp is None:
+            assert m is None
+        else:
+            assert m.group() == exp

--- a/tests/test_container/test_protocols.py
+++ b/tests/test_container/test_protocols.py
@@ -5,7 +5,13 @@ from typing import Optional
 
 import pytest
 
-from dicom_utils.container.protocols import SupportsManufacturer, SupportsPatientID, SupportsStudyUID, SupportsUID
+from dicom_utils.container.protocols import (
+    SupportsManufacturer,
+    SupportsPatientAge,
+    SupportsPatientID,
+    SupportsStudyUID,
+    SupportsUID,
+)
 
 
 class TestSupportsStudyUID:
@@ -125,3 +131,29 @@ class TestSupportsManufacturer:
             assert m is None
         else:
             assert m.group() == exp
+
+
+class TestSupportsPatientAge:
+    @pytest.fixture
+    def factory(self):
+        @dataclass
+        class Impl(SupportsPatientAge):
+            PatientAge: Optional[str] = None
+            PatientBirthDate: Optional[str] = None
+
+        return Impl
+
+    @pytest.mark.parametrize(
+        "age,exp",
+        [
+            pytest.param("095Y", 95),
+            pytest.param("020Y", 20),
+            pytest.param("99Y", 99),
+            pytest.param("32", 32),
+            pytest.param("", None),
+            pytest.param(None, None),
+        ],
+    )
+    def test_patient_age(self, factory, age, exp):
+        s = factory(age)
+        assert s.patient_age == exp

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -601,7 +601,7 @@ class TestMammogramFileRecord(TestDicomFileRecord):
         assert actual == expected
 
     @pytest.mark.parametrize(
-        "mtype,spot,mag,id,laterality,view_pos,uid,exp",
+        "mtype,spot,mag,id,laterality,view_pos,uid,secondary,for_proc,exp",
         [
             pytest.param(
                 MammogramType.FFDM,
@@ -611,6 +611,8 @@ class TestMammogramFileRecord(TestDicomFileRecord):
                 Laterality.LEFT,
                 ViewPosition.MLO,
                 "1",
+                False,
+                False,
                 "ffdm_lmlo_1.dcm",
             ),
             pytest.param(
@@ -621,6 +623,8 @@ class TestMammogramFileRecord(TestDicomFileRecord):
                 Laterality.RIGHT,
                 ViewPosition.CC,
                 "2",
+                False,
+                False,
                 "ffdm_rcc_2.dcm",
             ),
             pytest.param(
@@ -631,6 +635,8 @@ class TestMammogramFileRecord(TestDicomFileRecord):
                 Laterality.RIGHT,
                 ViewPosition.XCCL,
                 "1",
+                False,
+                False,
                 "synth_rxccl_spot_mag_id_1.dcm",
             ),
             pytest.param(
@@ -641,11 +647,27 @@ class TestMammogramFileRecord(TestDicomFileRecord):
                 Laterality.UNKNOWN,
                 ViewPosition.UNKNOWN,
                 "2",
+                False,
+                False,
                 "ffdm_2.dcm",
+            ),
+            pytest.param(
+                MammogramType.SYNTH,
+                True,
+                True,
+                True,
+                Laterality.RIGHT,
+                ViewPosition.XCCL,
+                "1",
+                True,
+                True,
+                "synth_rxccl_secondary_proc_spot_mag_id_1.dcm",
             ),
         ],
     )
-    def test_standardized_filename(self, mtype, spot, mag, id, laterality, view_pos, uid, exp, record_factory):
+    def test_standardized_filename(
+        self, mtype, spot, mag, id, laterality, view_pos, uid, secondary, for_proc, exp, record_factory
+    ):
         seq = []
         if spot:
             seq.append(make_view_modifier_code("spot compression"))
@@ -664,6 +686,8 @@ class TestMammogramFileRecord(TestDicomFileRecord):
             ViewModifierCodeSequence=seq,
             laterality=laterality,
             view_position=view_pos,
+            SOPClassUID=SecondaryCaptureImageStorage if secondary else None,
+            PresentationIntentType="FOR PROCESSING" if for_proc else None,
         )
         actual = record.standardized_filename(uid)
         assert isinstance(actual, StandardizedFilename)


### PR DESCRIPTION
Includes the following changes:
* Replace constant record count assertion in grouper with a warning. Depending on what helpers are used, the record count could change without it being a guaranteed error.
* Add tests / fixes for protocol member methods
* Add `SupportsPatientAge` protocol with helper for extracting age as an integer
* Add `is_cad` attribute to `SupportsGenerated` for identifying CAD program outputs
* Ensure modifiers from `standardized_filename` are properly inherited