### PR TITLE
Allow non-existent files in `from_dicom`

### DIFF
--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -492,8 +492,6 @@ class DicomFileRecord(
             dcm: Dicom file object
         """
         path = Path(path)
-        if not path.is_file():
-            raise FileNotFoundError(path)
         values = {tag.name: get_value(dcm, tag, None, try_file_meta=True) for tag in cls.get_required_tags()}
         values.update(overrides)
 

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -277,6 +277,16 @@ class TestDicomFileRecord(TestFileRecord):
         proto.__class__.from_file(proto.path)
         spy.assert_called_once()
 
+    @pytest.mark.parametrize("file_exists", [True, False])
+    def test_from_dicom(self, mocker, record_factory, file_exists):
+        proto = record_factory()
+        with pydicom.dcmread(proto.path) as dcm:
+            if not file_exists:
+                proto.path.unlink()
+                assert not proto.path.is_file()
+            result = proto.__class__.from_dicom(proto.path, dcm)
+        assert result == proto
+
     @pytest.mark.parametrize(
         "sop,series,exp",
         [


### PR DESCRIPTION
The `path.is_file()` check is not necessary in `from_dicom`, and it prevents reading from DICOM objects that don't have an associated file on disk.