### PR TITLE
Support site information in DicomFileRecord

### DIFF
--- a/dicom_utils/container/protocols.py
+++ b/dicom_utils/container/protocols.py
@@ -145,3 +145,14 @@ class SupportsManufacturer(Protocol):
         elif self.ManufacturerModelNumber and (m := pattern.search(self.ManufacturerModelNumber)):
             return m
         return None
+
+
+@runtime_checkable
+class SupportsSite(Protocol):
+    InstitutionAddress: Optional[str] = None
+    InstitutionName: Optional[str] = None
+    TreatmentSite: Optional[str] = None
+
+    @property
+    def site(self) -> Optional[str]:
+        return self.InstitutionAddress or self.TreatmentSite or self.InstitutionName

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -79,6 +79,7 @@ from .protocols import (
     SupportsManufacturer,
     SupportsPatientAge,
     SupportsPatientID,
+    SupportsSite,
     SupportsStudyDate,
     SupportsStudyUID,
     SupportsUID,
@@ -346,6 +347,7 @@ class DicomFileRecord(
     SupportsPatientID,
     SupportsPatientAge,
     SupportsGenerated,
+    SupportsSite,
 ):
     r"""Data structure for storing critical information about a DICOM file.
     File IO operations on DICOMs can be expensive, so this class collects all
@@ -374,6 +376,9 @@ class DicomFileRecord(
     PatientAge: Optional[str] = None
     PatientBirthDate: Optional[str] = None
     BodyPartThickness: Optional[str] = None
+    InstitutionAddress: Optional[str] = None
+    InstitutionName: Optional[str] = None
+    TreatmentSite: Optional[str] = None
 
     generated: bool = False
     is_cad: bool = False
@@ -381,6 +386,8 @@ class DicomFileRecord(
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, type(self)):
             return False
+        Tag.TreatmentSite
+        Tag.InstitutionAddress
 
         if self.SOPInstanceUID and other.SOPInstanceUID:
             return self.same_uid_as(other)

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -396,6 +396,26 @@ class TestDicomFileRecord(TestFileRecord):
             assert rec1 != rec2
             assert rec1 == rec3
 
+    @pytest.mark.parametrize(
+        "addr,name,ts,exp",
+        [
+            (None, None, None, None),
+            ("foo", None, None, "foo"),
+            (None, "foo", None, "foo"),
+            (None, None, "foo", "foo"),
+            ("foo", "bar", "baz", "foo"),
+            (None, "bar", "baz", "baz"),
+        ],
+    )
+    def test_site(self, addr, name, ts, exp, record_factory):
+        rec = record_factory("foo.dcm")
+        rec = rec.replace(
+            InstitutionAddress=addr,
+            InstitutionName=name,
+            TreatmentSite=ts,
+        )
+        assert rec.site == exp
+
 
 class TestDicomImageFileRecord(TestDicomFileRecord):
     @pytest.fixture


### PR DESCRIPTION
Adds a `SupportsSite` protocol that tracks site information through `InstitutionAddress`, `TreatmentSite`, and `InstitutionName`. A `site` property is provided to return a single site identifier based on the first available tag from these three tags.