### PR TITLE
Support NVJPEG2K

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,15 @@ commands:
     # 3. Clone the desired submodule
     # 4. Go back to step 1 for any additional submodules
     parameters:
-    repo:
-      default: "none"
-      type: string
-    ssh_key_fingerprint:
-      default: "none"
-      type: string
-    working_directory:
-      default: "."
-      type: string
+      repo:
+        default: "none"
+        type: string
+      ssh_key_fingerprint:
+        default: "none"
+        type: string
+      working_directory:
+        default: "."
+        type: string
     steps:
       - run: rm -f $HOME/.ssh/config # Old config may contain an old key
       - add_ssh_keys:
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: Run tests
           command: make test-ci
-      - setup_node_modules
+      - install_npm
       - run:
           name: Run static type checking
           command: make types

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,66 +1,88 @@
 version: 2.1
 
-
 orbs:
   codecov: codecov/codecov@1.0.2
 
-
 commands:
-    setup_node_modules:
-        steps:
-            - run: sudo apt update
-            - run: sudo apt install -y npm
-            - run: sudo npm cache clean -f
-            - run: sudo npm install -g n
-            - run: sudo n stable
-            - run:
-                name: Install static type checker
-                command: npm ci
-
+  checkout_private_submodule:
+    # Why is checking out a private submodule so complicated?
+    # 1. GitHub does not allow a public key to be copied as a deploy key into multiple repos.
+    #    Therefore, each submodule needs its own unique deploy public key.
+    # 2. If we add all submodule deploy private keys at once, CircleCI
+    #    will only use the first deploy private key added.
+    # Therefore, we do this:
+    # 1. Remove .ssh/config so we don't use any previously added keys
+    # 2. Add the key which is able to access the submodule we are about to clone
+    # 3. Clone the desired submodule
+    # 4. Go back to step 1 for any additional submodules
+    parameters:
+    repo:
+      default: "none"
+      type: string
+    ssh_key_fingerprint:
+      default: "none"
+      type: string
+    working_directory:
+      default: "."
+      type: string
+    steps:
+      - run: rm -f $HOME/.ssh/config # Old config may contain an old key
+      - add_ssh_keys:
+          fingerprints:
+            - <<parameters.ssh_key_fingerprint>>
+      - run: cd <<parameters.working_directory>> && git submodule update --init <<parameters.repo>>
+  install_npm:
+    steps:
+      - run: sudo apt update
+      - run: sudo apt install -y npm
+      - run: sudo npm cache clean -f
+      - run: sudo npm install -g n
+      - run: sudo n stable
 
 jobs:
-    check_code_quality:
-        docker:
-            - image: circleci/python:3.10
-        steps:
-            - checkout
-            - run: 
-                name: Run quality tests
-                command: make quality
+  check_code_quality:
+    docker:
+      - image: circleci/python:3.10
+    steps:
+      - checkout
+      - run:
+          name: Run quality tests
+          command: make quality
 
-    run_tests:
-        docker:
-            - image: circleci/python:3.10
-        steps:
-            - checkout
-            - run:
-                name: Install dependencies
-                command: make init
-            - save_cache:
-                paths:
-                  - ~/.cache/pip
-                key: v1-dependencies-{{ checksum "setup.py" }}
-            - run:
-                name: Run tests
-                command: make test-ci
-            - setup_node_modules
-            - run:
-                name: Run static type checking
-                command: make types
-            - codecov/upload:
-                file: coverage.xml
-
+  run_tests:
+    docker:
+      - image: circleci/python:3.10
+    steps:
+      - checkout
+      - checkout_private_submodule:
+          repo: pynvjpeg2k
+          ssh_key_fingerprint: ab:1b:ef:f1:39:f5:dd:f1:97:de:0b:c5:8a:2a:58:52
+      - run:
+          name: Install dependencies
+          command: make init
+      - save_cache:
+          paths:
+            - ~/.cache/pip
+          key: v1-dependencies-{{ checksum "setup.py" }}
+      - run:
+          name: Run tests
+          command: make test-ci
+      - setup_node_modules
+      - run:
+          name: Run static type checking
+          command: make types
+      - codecov/upload:
+          file: coverage.xml
 
 workflow_filters: &workflow_filters
-    filters:
-        branches:
-            only:
-                - master
-                - feat/circleci
-
+  filters:
+    branches:
+      only:
+        - master
+        - feat/circleci
 
 workflows:
-    build_and_test:
-        jobs:
-            - check_code_quality
-            - run_tests
+  build_and_test:
+    jobs:
+      - check_code_quality
+      - run_tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pynvjpeg2k"]
+	path = pynvjpeg2k
+	url = git@github.com:medcognetics/pynvjpeg2k.git

--- a/dicom_utils/cli/decompress.py
+++ b/dicom_utils/cli/decompress.py
@@ -5,9 +5,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from time import time
 
-import numpy as np
 import pydicom
-from PIL import Image
 
 from ..dicom import decompress
 

--- a/dicom_utils/cli/decompress.py
+++ b/dicom_utils/cli/decompress.py
@@ -3,6 +3,7 @@
 import argparse
 from argparse import ArgumentParser
 from pathlib import Path
+from time import time
 
 import pydicom
 
@@ -33,10 +34,15 @@ def main(args: argparse.Namespace) -> None:
     if not dest.parent.is_dir():
         raise NotADirectoryError(dest.parent)
 
+    start_time = time()
     with pydicom.dcmread(path) as dcm:
         dcm = decompress(dcm, strict=args.strict, use_nvjpeg=args.gpu, batch_size=args.batch_size, verbose=args.verbose)
         assert not dcm.file_meta.TransferSyntaxUID.is_compressed
         dcm.save_as(dest)
+    end_time = time()
+    if args.verbose:
+        total_time = end_time - start_time
+        print(f"Total time (s): {total_time}")
 
 
 def entrypoint():

--- a/dicom_utils/cli/decompress.py
+++ b/dicom_utils/cli/decompress.py
@@ -31,13 +31,6 @@ def get_parser(parser: ArgumentParser = ArgumentParser()) -> ArgumentParser:
     return parser
 
 
-def to_img(x: np.ndarray) -> Image.Image:
-    x = x.astype(np.float32)
-    x = (x - x.min()) / (x.max() - x.min()) * 255
-    x = x.astype(np.uint8)
-    return Image.fromarray(x)
-
-
 def main(args: argparse.Namespace) -> None:
     path = Path(args.path)
     dest = Path(args.dest)

--- a/dicom_utils/cli/decompress.py
+++ b/dicom_utils/cli/decompress.py
@@ -48,12 +48,14 @@ def main(args: argparse.Namespace) -> None:
 
     start_time = time()
     with pydicom.dcmread(path) as dcm:
+        dcmread_time = time() - start_time
         dcm = decompress(dcm, strict=args.strict, use_nvjpeg=args.gpu, batch_size=args.batch_size, verbose=args.verbose)
         assert not dcm.file_meta.TransferSyntaxUID.is_compressed
         dcm.save_as(dest)
     end_time = time()
     if args.verbose:
         total_time = end_time - start_time
+        print(f"pydicom.dcmread time (s): {dcmread_time}")
         print(f"Total time (s): {total_time}")
 
     if args.test:

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -419,6 +419,8 @@ def nvjpeg_decompress(
     # NOTE: pynvjpeg.decode_frames_jpeg2k should be faster, but it's not as reliable.
     # For example, pynvjpeg.decode_frames_jpeg2k doesn't work with Pydicom's test file "RG1_J2KR.dcm"
     # This approach seems to be about as fast, but might be faster if batch_size was used.
+    # The optimal approach would probably be to leverage pydicom.encaps.get_frame_offsets
+    # and let pynvjpeg create the frame stack.
     frame_stack = functools.reduce(lambda a, b: a + b, VolumeHandler.iterate_frames(dcm))
     decoded_frames = pynvjpeg.decode_jpeg2k(frame_stack, len(frame_stack), rows, cols)
 

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -396,7 +396,7 @@ def nvjpeg_decompress(
     if not nvjpeg2k_is_available():
         raise ImportError("pynvjpeg is not available")
 
-    num_frames = int(dcm.NumberOfFrames)
+    num_frames = int(dcm.get("NumberOfFrames", 1))
     rows = dcm.Rows
     cols = dcm.Columns
 

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -23,6 +23,7 @@ from .volume import KeepVolume, VolumeHandler
 
 
 try:
+    # NOTE: This module will be open-sourced in the future
     import pynvjpeg  # type: ignore
 except Exception:
     pynvjpeg = None

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -415,10 +415,17 @@ def nvjpeg_decompress(
         # NOTE: batched decoding may add padding, which will be included in stdout.
         # Manually compute the expected number of bytes to read
         shape = (num_frames, dcm.Rows, dcm.Columns)
-        expected_bytes = shape[0] * shape[1] * shape[2] * BYTES_PER_UINT16
+        expected_bytes = shape[0] * shape[1] * shape[2]
 
         # read data into numpy array and reshape
-        img_bytes = process.stdout.read(expected_bytes)
-        pixels = np.frombuffer(img_bytes, dtype=np.uint16).reshape(*shape)
+        img_bytes = process.stdout.read(expected_bytes * BYTES_PER_UINT16)
+        np.fromfile
+        pixels = np.frombuffer(
+            img_bytes,
+            dtype=np.uint16,
+            count=expected_bytes,
+        ).reshape(*shape)
+        process.kill()
+        process.poll()
 
         return pixels

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -402,8 +402,6 @@ def nvjpeg_decompress(
 
     batch_size = _nvjpeg_get_batch_size(batch_size, num_frames)
     pixels = dcm.PixelData
-    t1 = time()
     assert pynvjpeg is not None  # To fix a type error on the next line even though we already checked for this
     result = pynvjpeg.decode_frames_jpeg2k(pixels, len(pixels), rows, cols, batch_size)
-    t2 = time()
     return result

--- a/dicom_utils/volume.py
+++ b/dicom_utils/volume.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from itertools import islice

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,14 @@
 -e .
+
+# -e pynvjpeg2k  # Run this manually if you wish to install pynvjpeg2k (not required)
+#
+# The following steps may be required:
+#
+# 1. apt install cmake
+#
+# 2. Add CUDA tools to path
+# CUDA_FOLDER="cuda-12.0"
+# export PATH="/usr/local/$CUDA_FOLDER/bin:$PATH"
+# export LD_LIBRARY_PATH="/usr/local/$CUDA_FOLDER/lib64:$LD_LIBRARY_PATH"
+#
+# 3. apt -y install python3-pybind11

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def dicom_object(dicom_file):
 
 @pytest.fixture
 def dicom_file_j2k() -> str:
-    filename = get_testdata_file("JPEG2000.dcm")
+    filename = get_testdata_file("RG1_J2KR.dcm")
     assert isinstance(filename, str)
     return filename
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,10 +36,22 @@ def dicom_object(dicom_file):
 
 
 @pytest.fixture
-def dicom_file_j2k() -> str:
+def dicom_file_j2k_uint16() -> str:
     filename = get_testdata_file("RG1_J2KR.dcm")
     assert isinstance(filename, str)
     return filename
+
+
+@pytest.fixture
+def dicom_file_j2k_int16() -> str:
+    filename = get_testdata_file("JPEG2000.dcm")
+    assert isinstance(filename, str)
+    return filename
+
+
+@pytest.fixture(params=["dicom_file_j2k_uint16", "dicom_file_j2k_int16"])
+def dicom_file_j2k(request):
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -117,6 +117,22 @@ class TestReadDicomImage:
         assert array.shape[-2:] == (100, 100)
         assert array.dtype == np.uint8
 
+    @pytest.mark.ci_skip  # CircleCI will not have a GPU
+    def test_nvjpeg(self, dicom_file_j2k: str):
+        ds = pydicom.dcmread(dicom_file_j2k)
+
+        start_time = time.time()
+        cpu_decompressed = read_dicom_image(ds, use_nvjpeg=False)
+        cpu_time = time.time() - start_time
+
+        start_time = time.time()
+        gpu_decompressed = read_dicom_image(ds, use_nvjpeg=True)
+        gpu_time = time.time() - start_time
+
+        assert gpu_time < cpu_time
+        assert cpu_decompressed.shape == gpu_decompressed.shape
+        assert (cpu_decompressed == gpu_decompressed).all()
+
 
 def test_deprecated_is_inverted(dicom_object):
     with pytest.warns(DeprecationWarning):

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -127,7 +127,7 @@ class TestReadDicomImage:
             ds = pydicom.dcmread(dicom_file_j2k)
             image = read_dicom_image(ds, use_nvjpeg=use_nvjpeg, nvjpeg_batch_size=BATCH_SIZE)
             if use_nvjpeg:
-                mocked_get_batch_size.assert_called_with(BATCH_SIZE, ds.NumberOfFrames)
+                mocked_get_batch_size.assert_called_with(BATCH_SIZE, ds.get("NumberOfFrames", 1))
             else:
                 mocked_get_batch_size.assert_not_called
             return image

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -119,19 +119,17 @@ class TestReadDicomImage:
 
     @pytest.mark.ci_skip  # CircleCI will not have a GPU
     def test_nvjpeg(self, dicom_file_j2k: str):
-        ds = pydicom.dcmread(dicom_file_j2k)
+        def read_image(use_nvjpeg: bool):
+            start_time = time.time()
+            image = read_dicom_image(pydicom.dcmread(dicom_file_j2k), use_nvjpeg=use_nvjpeg)
+            return image, time.time() - start_time
 
-        start_time = time.time()
-        cpu_decompressed = read_dicom_image(ds, use_nvjpeg=False)
-        cpu_time = time.time() - start_time
-
-        start_time = time.time()
-        gpu_decompressed = read_dicom_image(ds, use_nvjpeg=True)
-        gpu_time = time.time() - start_time
+        cpu_image, cpu_time = read_image(False)
+        gpu_image, gpu_time = read_image(True)
 
         assert gpu_time < cpu_time
-        assert cpu_decompressed.shape == gpu_decompressed.shape
-        assert (cpu_decompressed == gpu_decompressed).all()
+        assert cpu_image.shape == gpu_image.shape
+        assert (cpu_image == gpu_image).all()
 
 
 def test_deprecated_is_inverted(dicom_object):

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -12,7 +12,7 @@ from numpy.random import default_rng
 from pydicom.uid import ImplicitVRLittleEndian, RLELossless
 
 from dicom_utils import KeepVolume, SliceAtLocation, UniformSample, read_dicom_image
-from dicom_utils.dicom import data_handlers, default_data_handlers, is_inverted, set_pixels
+from dicom_utils.dicom import data_handlers, default_data_handlers, image_is_uint16, is_inverted, set_pixels
 
 
 class TestReadDicomImage:
@@ -126,7 +126,7 @@ class TestReadDicomImage:
         def read_image(use_nvjpeg: bool):
             ds = pydicom.dcmread(dicom_file_j2k)
             image = read_dicom_image(ds, use_nvjpeg=use_nvjpeg, nvjpeg_batch_size=BATCH_SIZE)
-            if use_nvjpeg:
+            if use_nvjpeg and image_is_uint16(ds):
                 mocked_get_batch_size.assert_called_with(BATCH_SIZE, ds.get("NumberOfFrames", 1))
             else:
                 mocked_get_batch_size.assert_not_called

--- a/tests/test_main/test_decompress.py
+++ b/tests/test_main/test_decompress.py
@@ -39,6 +39,8 @@ def test_decompress(get_dicom_file, tmp_path, start_compressed):
         sys.argv[0],
         str(dicom_file),
         str(dest),
+        "--verbose",
+        "--test",
     ]
     runpy.run_module("dicom_utils.cli.decompress", run_name="__main__", alter_sys=True)
 


### PR DESCRIPTION
Adds support for NVJPEG2K for accelerated decoding of JPEG2000 compressed 3D images. This was solved by utilizing an example C++ script provided by Nvidia. Compressed data is written to temporary files which are decompressed by the script to other temporary files and then read back in to numpy arrays.

Sample decode performance:
```
Total decoding time: 0.340837
Avg decoding time per image: 0.00757416
Avg decode speed  (in images per sec): 132.028
Avg decoding time per batch: 0.113612
```

Support depends on [this](https://github.com/NVIDIA/CUDALibrarySamples/tree/master/nvJPEG2000/nvJPEG2000-Decoder-Pipelined) C++ script and a copy of nvjpeg2k. At this point in time, setting up the C++ script and nvjpeg2k is a manual process.

Steps:
1. Clone [this](https://github.com/NVIDIA/CUDALibrarySamples) repo.
2. cd to `nvJPEG2000/nvJPEG2000-Decoder-Pipelined`
3. Add `set(NVJPEG2K_PATH /path/to/nvjpeg2k)` in `CMakeLists.txt`
4. Change `lib64` refernces for nvjpeg2k to `lib`
5. Install `nvcc` if it is not already installed. On ubuntu, `nvidia-cuda-toolkit` provides `nvcc`
6. `mkdir build`
7. `cd build && cmake ..`
8. `cmake --build .`
9. C++ script will be built as `nvjpeg2k_dec_pipelined`
10. export `NVJPEG2K_PATH=/path/to/script`
11. Now `dicom-decomp` can be run with the `--gpu` and `--batch-size` options for accelerated decompression

Future tasks:
* GPU decoding is not under test because we don't have a mechanism to create a small JPEG2000 compressed test file. Having tests would be ideal
* Writing a custom C++ binding for nvjpeg2k decode would likely yield better performance and simplify the setup. Total decompression time seems longer than what is indicated by the NVJPEG2K performance outputs.
* See if there is any way to speed up the script without custom C++ bindings. Are we sure that all exchanges between Python / C++ are happending using in-memory files?