### PR TITLE
Add `get_standard_mammo_view_lookup` classmethod

### DIFF
--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 from abc import ABC
+from collections import defaultdict
 from dataclasses import dataclass, field, fields, replace
 from functools import cached_property, partial
 from io import BytesIO, IOBase
@@ -752,15 +753,15 @@ class MammogramFileRecord(DicomImageFileRecord):
     def get_standard_mammo_view_lookup(
         cls, records: Iterable["MammogramFileRecord"]
     ) -> Dict[MammogramView, List["MammogramFileRecord"]]:
-        needed_views: Dict[MammogramView, List[MammogramFileRecord]] = {k: [] for k in STANDARD_MAMMO_VIEWS}
+        needed_views: Dict[MammogramView, List[MammogramFileRecord]] = defaultdict(list)
         for rec in records:
             # only consider standard views
             if not isinstance(rec, MammogramFileRecord) or not rec.is_standard_mammo_view:
                 continue
             key = rec.mammogram_view
-            if key in needed_views:
+            if key in STANDARD_MAMMO_VIEWS:
                 needed_views[key].append(rec)
-        return {k: v for k, v in needed_views.items() if v}
+        return needed_views
 
     @classmethod
     def is_complete_mammo_case(cls, records: Iterable["MammogramFileRecord"]) -> bool:


### PR DESCRIPTION
Adds a classmethod for extracting a dict mapping standard `MammogramView`s to lists of `MammogramFileRecord`s with that view. This is helpful because it enables the comparison of two incomplete studies based on what fraction of the required 4 standard views each study contains.