### PR TITLE
Support reading input filepaths of various types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-ci: $(VENV)/bin/activate $(VENV)/bin/activate-test ## runs CI-only tests
 		-m "not ci_skip" \
 		./tests/
 
-types: $(VENV)/bin/activate node_modules pyrightconfig.json
+types: $(VENV)/bin/activate $(VENV)/bin/activate-test node_modules pyrightconfig.json
 	npx --no-install pyright tests $(PROJECT) -p pyrightconfig.json
 
 $(PROJECT)/_tag_enum.py: $(VENV)/bin/activate tag_enum.py
@@ -109,7 +109,7 @@ $(VENV)/bin/activate: setup.py requirements.txt
 	$(PYTHON) -m pip install -e .
 	touch $(VENV)/bin/activate
 
-$(VENV)/bin/activate-%: requirements.%.txt
+$(VENV)/bin/activate-%: requirements.%.txt $(VENV)/bin/activate 
 	test -d $(VENV) || $(PY_VER) -m venv $(VENV)
 	$(PYTHON) -m pip install -U pip 
 	$(PYTHON) -m pip install -r $<

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -311,7 +311,7 @@ def iterate_input_path(
     Inputs are processed as follows:
         * If the path is a text file, it is assumed to contain a list of paths to process. Each line is
           stripped and processed as a path. Invalid paths will raise ``FileNotFoundError`` if ``ignore_missing``
-          is ``True``.
+          is ``False``.
         * If the path is a file, it will be yielded.
         * If the path is a directory, it will be recursively searched for files up to ``max_depth``.
           If ``max_depth`` is reached, the directory will be yielded instead of recursing further.

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -300,12 +300,18 @@ def iterate_filepaths(
             raise FileNotFoundError(path)
 
 
-def iterate_input_path(path: Path, max_depth: Optional[int] = None, _depth: int = 0) -> Iterator[Path]:
+def iterate_input_path(
+    path: Path,
+    max_depth: Optional[int] = None,
+    ignore_missing: bool = False,
+    _depth: int = 0,
+) -> Iterator[Path]:
     r"""Iterates over an input path, yielding all files found.
 
     Inputs are processed as follows:
         * If the path is a text file, it is assumed to contain a list of paths to process. Each line is
-          stripped and processed as a path.
+          stripped and processed as a path. Invalid paths will raise ``FileNotFoundError`` if ``ignore_missing``
+          is ``True``.
         * If the path is a file, it will be yielded.
         * If the path is a directory, it will be recursively searched for files up to ``max_depth``.
           If ``max_depth`` is reached, the directory will be yielded instead of recursing further.
@@ -321,23 +327,23 @@ def iterate_input_path(path: Path, max_depth: Optional[int] = None, _depth: int 
         # possibly recurse into subdirectories
         if max_depth is None or _depth < max_depth:
             for child in path.iterdir():
-                yield from iterate_input_path(child, max_depth, _depth + 1)
+                yield from iterate_input_path(child, max_depth, _depth=_depth + 1)
         # otherwise yield the directory itself
         else:
             yield path
 
-    # if path is a text file, read all lines in the file
-    elif path.is_file() and path.suffix == ".txt":
+    # if path is a text file and we are at depth 0, read all lines in the file
+    elif path.is_file() and path.suffix == ".txt" and _depth == 0:
         with open(path, "r") as f:
             for line in f:
-                yield from iterate_input_path(Path(line.strip()), max_depth)
+                yield from iterate_input_path(Path(line.strip()), max_depth, ignore_missing)
 
     # if path is any other file, return it
     elif path.is_file():
         yield path
 
-    else:
-        raise ValueError(f"Invalid input path: {path}")
+    elif not ignore_missing:
+        raise FileNotFoundError(path)
 
 
 R = TypeVar("R", bound=FileRecord)

--- a/dicom_utils/container/output.py
+++ b/dicom_utils/container/output.py
@@ -182,7 +182,6 @@ class ManifestOutput(Output):
         collection: RecordCollection,
         dest: Path,
     ) -> Iterator[WriteResult]:
-
         # we want the manifest to reflect symlink paths and real paths.
         symlink_collection = RecordCollection()
         for symlink_path, rec in iterate_symlinks(collection, dest):

--- a/tests/test_container/test_collection.py
+++ b/tests/test_container/test_collection.py
@@ -23,7 +23,64 @@ from dicom_utils.container import (
     StudyUID,
     record_iterator,
 )
+from dicom_utils.container.collection import iterate_input_path
 from dicom_utils.dicom_factory import DicomFactory
+
+
+class TestIterateInputPath:
+    def test_file(self, tmp_path):
+        path = Path(tmp_path, "test.dcm")
+        path.touch()
+        result = list(iterate_input_path(path))
+        assert result == [path]
+
+    @pytest.mark.parametrize("max_depth", [None, 0, 1])
+    def test_dir(self, tmp_path, max_depth):
+        path = Path(tmp_path, "dir")
+        path.mkdir()
+        subfile = Path(path, "test.dcm")
+        subfile.touch()
+        result = list(iterate_input_path(path, max_depth))
+        if max_depth == 0:
+            assert result == [path]
+        else:
+            assert result == list(path.iterdir())
+
+    def test_text_file_of_files(self, tmp_path):
+        path = Path(tmp_path, "test.txt")
+        subdir = Path(tmp_path, "dir")
+        subdir.mkdir()
+        with path.open("w") as f:
+            targets = []
+            for i in range(3):
+                p = Path(subdir, f"test{i}.dcm")
+                p.touch()
+                targets.append(p)
+                f.write(f"{p}\n")
+        result = list(iterate_input_path(path))
+        assert result == targets
+
+    @pytest.mark.parametrize("max_depth", [None, 0, 1])
+    def test_text_file_of_dirs(self, tmp_path, max_depth):
+        path = Path(tmp_path, "test.txt")
+        subdir = Path(tmp_path, "dir")
+        subdir.mkdir()
+        with path.open("w") as f:
+            dir_targets = []
+            file_targets = []
+            for i in range(3):
+                subsubdir = Path(subdir, f"subsubdir{i}")
+                subsubdir.mkdir()
+                p = Path(subsubdir, f"test{i}.dcm")
+                p.touch()
+                dir_targets.append(subsubdir)
+                file_targets.append(p)
+                f.write(f"{subsubdir}\n")
+        result = list(iterate_input_path(path, max_depth))
+        if max_depth == 0:
+            assert result == dir_targets
+        else:
+            assert result == file_targets
 
 
 @pytest.fixture

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -670,7 +670,7 @@ class TestMammogramFileRecord(TestDicomFileRecord):
             record = record.replace(SOPClassUID=SecondaryCaptureImageStorage)
         # should be incomplete until after this loop
         records: List[MammogramFileRecord] = []
-        for (laterality, view_pos) in STANDARD_MAMMO_VIEWS:
+        for laterality, view_pos in STANDARD_MAMMO_VIEWS:
             assert not MammogramFileRecord.is_complete_mammo_case(records)
             rec = replace(record, laterality=laterality, view_position=view_pos)
             records.append(rec)


### PR DESCRIPTION
Adds a method `iterate_input_path` to aid in manging (CLI) inputs which may be files, directories, or text files containing paths of files or directories.

Implementation notes:
* A `max_depth` arg is used to control recursion depth. This can be used in situations where the desired outputs are directories instead of files.
* No special treatment is given to DICOM files. File filtering can be performed on the iterator if desired.