### PR TITLE
Add `SupportsDataSetInfo` protocol

### DIFF
--- a/dicom_utils/container/__init__.py
+++ b/dicom_utils/container/__init__.py
@@ -3,9 +3,11 @@
 from .collection import FILTER_REGISTRY, RecordCollection, RecordCreator, RecordFilter, record_iterator
 from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID, TransferSyntaxUID
 from .protocols import (
+    SupportsDataSetInfo,
     SupportsGenerated,
     SupportsManufacturer,
     SupportsPatientID,
+    SupportsSite,
     SupportsStudyDate,
     SupportsStudyID,
     SupportsUID,
@@ -48,4 +50,6 @@ __all__ = [
     "SupportsStudyID",
     "SupportsUID",
     "SupportsStudyID",
+    "SupportsSite",
+    "SupportsDataSetInfo",
 ]

--- a/dicom_utils/container/protocols.py
+++ b/dicom_utils/container/protocols.py
@@ -156,3 +156,12 @@ class SupportsSite(Protocol):
     @property
     def site(self) -> Optional[str]:
         return self.InstitutionAddress or self.TreatmentSite or self.InstitutionName
+
+
+@runtime_checkable
+class SupportsDataSetInfo(Protocol):
+    DataSetSource: Optional[str] = None
+    DataSetName: Optional[str] = None
+    DataSetDescription: Optional[str] = None
+    DataSetType: Optional[str] = None
+    DataSetSubtype: Optional[str] = None

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -76,6 +76,7 @@ from ..types import ViewPosition, get_value, iterate_view_modifier_codes
 from .helpers import SOPUID, ImageUID, SeriesUID, StudyUID
 from .helpers import TransferSyntaxUID as TSUID
 from .protocols import (
+    SupportsDataSetInfo,
     SupportsGenerated,
     SupportsManufacturer,
     SupportsPatientAge,
@@ -349,6 +350,7 @@ class DicomFileRecord(
     SupportsPatientAge,
     SupportsGenerated,
     SupportsSite,
+    SupportsDataSetInfo,
 ):
     r"""Data structure for storing critical information about a DICOM file.
     File IO operations on DICOMs can be expensive, so this class collects all
@@ -380,6 +382,11 @@ class DicomFileRecord(
     InstitutionAddress: Optional[str] = None
     InstitutionName: Optional[str] = None
     TreatmentSite: Optional[str] = None
+    DataSetName: Optional[str] = None
+    DataSetSource: Optional[str] = None
+    DataSetDescription: Optional[str] = None
+    DataSetType: Optional[str] = None
+    DataSetSubtype: Optional[str] = None
 
     generated: bool = False
     is_cad: bool = False


### PR DESCRIPTION
Adds various fields related to dataset info. This will be used to track the association of DICOM files with various data sources and batches.