### PR TITLE
Allow `Output` to run record/collection helpers

### DIFF
--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -22,6 +22,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -93,8 +94,10 @@ def apply_helpers(collection: C, helpers: Iterable[CollectionHelper], index: int
         if not isinstance(h, CollectionHelper):
             raise TypeError(f"type {type(h)} is not a `CollectionHelper`")
         logger.debug(f"Applying collection helper {type(h)}")
-        collection = h(collection, index)
-    return collection
+        collection = h(cast(C, collection), index)
+        if not isinstance(collection, RecordCollection):
+            raise TypeError(f"Collection helper {type(h)} returned invalid type {type(collection)}")
+    return cast(C, collection)
 
 
 class RecordCreator:

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -938,8 +938,10 @@ def apply_helpers(path: PathLike, rec: R, helpers: Iterable[RecordHelper]) -> R:
         if not isinstance(h, RecordHelper):
             raise TypeError(f"type {type(h)} is not a `RecordHelper`")
         logger.debug(f"Applying helper {type(h)} to {path}")
-        rec = h(path, rec)
-    return rec
+        rec = h(path, cast(R, rec))
+        if not isinstance(rec, FileRecord):
+            raise TypeError(f"Expected `FileRecord` from {type(h)}, got {type(rec)}")
+    return cast(R, rec)
 
 
 def apply_read_helpers(obj: T, record_type: Type[FileRecord], helpers: Iterable[RecordHelper]) -> T:

--- a/tests/test_container/test_output.py
+++ b/tests/test_container/test_output.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+from typing import ClassVar, Type
+
+import pytest
+
+from dicom_utils.container import HELPER_REGISTRY, FileRecord, MammogramFileRecord, RecordHelper
+from dicom_utils.container.collection import CollectionHelper
+from dicom_utils.container.input import Input
+from dicom_utils.container.output import ManifestOutput, Output, SymlinkFileOutput, is_2d_mammogram
+from dicom_utils.dicom_factory import CompleteMammographyStudyFactory
+
+
+@pytest.fixture
+def dicom_files(tmp_path):
+    paths = []
+    for i in range(3):
+        fact = CompleteMammographyStudyFactory(seed=i, PatientID=f"Patient{i}", StudyInstanceUID=f"Study{i}")
+        for dcm in fact():
+            path = (tmp_path / dcm.SOPInstanceUID).with_suffix(".dcm")
+            dcm.save_as(path)
+            paths.append(path)
+    return paths
+
+
+@HELPER_REGISTRY(name="set-implant")
+class SetImplantHelper(RecordHelper):
+    def __call__(self, path, record):
+        if isinstance(record, MammogramFileRecord):
+            record = record.replace(BreastImplantPresent="Y")
+        return record
+
+
+@HELPER_REGISTRY(name="add-new")
+class AddNewRecord(CollectionHelper):
+    def __call__(self, collection, *args, **kwargs):
+        rec = FileRecord(Path("dummy.dcm"))
+        collection.add(rec)
+        return collection
+
+
+def is_3d_case(col):
+    return any(isinstance(rec, MammogramFileRecord) and rec.is_2d for rec in col)
+
+
+class BaseOutputTest:
+    INPUT_TYPE: ClassVar[Type[Output]]
+    DEFAULT_LEN: ClassVar[int] = 3
+    DEFAULT_IMAGES: ClassVar[int] = 12
+
+    def test_basic(self, tmp_path, dicom_files):
+        source = tmp_path
+        dest = Path(tmp_path, "dest")
+        dest.mkdir()
+        inp = Input(source, use_bar=False)
+        output = self.INPUT_TYPE(dest)
+        result = output(inp)
+        assert len(result) == self.DEFAULT_LEN
+        for r in result.values():
+            assert len(r) == self.DEFAULT_IMAGES  # type: ignore
+            assert all(f.path.is_file() for f in r)
+
+    def test_record_filter(self, tmp_path, dicom_files):
+        source = tmp_path
+        dest = Path(tmp_path, "dest")
+        dest.mkdir()
+        inp = Input(source, use_bar=False)
+        output = self.INPUT_TYPE(dest, record_filter=is_2d_mammogram)
+        result = output(inp)
+        assert len(result) == self.DEFAULT_LEN
+        for r in result.values():
+            for write_result in r:
+                assert all(not isinstance(rec, MammogramFileRecord) or rec.is_2d for rec in write_result.collection)
+
+    def test_record_helper(self, tmp_path, dicom_files):
+        source = tmp_path
+        dest = Path(tmp_path, "dest")
+        dest.mkdir()
+        inp = Input(source, use_bar=False)
+        output = self.INPUT_TYPE(dest, helpers=["set-implant"])
+        result = output(inp)
+        assert len(result) == self.DEFAULT_LEN
+        for r in result.values():
+            assert len(r) == self.DEFAULT_IMAGES  # type: ignore
+            for write_result in r:
+                assert all(not isinstance(rec, MammogramFileRecord) or rec.has_uid for rec in write_result.collection)
+
+
+class TestSymlinkFileOutput(BaseOutputTest):
+    INPUT_TYPE: ClassVar[Type[Output]] = SymlinkFileOutput
+
+    def test_collection_filter(self, tmp_path, dicom_files):
+        source = tmp_path
+        dest = Path(tmp_path, "dest")
+        dest.mkdir()
+        inp = Input(source, use_bar=False)
+        output = self.INPUT_TYPE(dest, record_filter=is_3d_case)
+        result = output(inp)
+        assert len(result) == 0
+
+    def test_collection_filter_preserves_collection(self, tmp_path, dicom_files):
+        source = tmp_path
+        dest = Path(tmp_path, "dest")
+        dest.mkdir()
+        inp = Input(source, use_bar=False)
+        output = self.INPUT_TYPE(dest, record_filter=is_3d_case)
+        result = output(inp)
+        assert len(result) == 0
+        output = self.INPUT_TYPE(dest)
+        result = output(inp)
+        assert len(result) == self.DEFAULT_LEN
+
+    def test_collection_helper(self, tmp_path, dicom_files):
+        source = tmp_path
+        dest = Path(tmp_path, "dest")
+        dest.mkdir()
+        inp = Input(source, use_bar=False)
+        output = self.INPUT_TYPE(dest, helpers=["add-new"], threads=True)
+        result = output(inp)
+        assert len(result) == self.DEFAULT_LEN
+        for r in result.values():
+            assert len(r) == self.DEFAULT_IMAGES + 1  # type: ignore
+            for write_result in r:
+                assert any(rec.path.name == "dummy.dcm" for rec in write_result.collection)
+
+
+class TestManifestOutput(BaseOutputTest):
+    INPUT_TYPE: ClassVar[Type[Output]] = ManifestOutput
+    DEFAULT_LEN: ClassVar[int] = 3
+    DEFAULT_IMAGES: ClassVar[int] = 1


### PR DESCRIPTION
This is needed in situations where an `Output` must modify the input collection in some way without impacting how other `Output`s are processed.

Also improves test coverage for `Output` subclasses. 