### PR TITLE
Add `importorskip` guard for `test_nvjpeg`

### DIFF
--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -538,13 +538,22 @@ class ViewPosition(EnumMixin):
             return ""
         return self.name.lower()
 
+    @property
+    def is_standard_view(self) -> bool:
+        return self in {self.CC, self.MLO}
+
+    @property
+    def is_mlo_like(self) -> bool:
+        return self in {self.MLO, self.ML, self.LMO, self.LM}
+
+    @property
+    def is_cc_like(self) -> bool:
+        return self in {self.CC, self.XCCL, self.XCCM}
+
 
 class MammogramView(NamedTuple):
     laterality: Laterality = Laterality.UNKNOWN
     view: ViewPosition = ViewPosition.UNKNOWN
-
-    def __repr__(self):
-        return f"{self.laterality.short_str}{self.view.short_str}"
 
     @classmethod
     def create(cls, laterality: Optional[Laterality] = None, view: Optional[ViewPosition] = None) -> "MammogramView":
@@ -565,11 +574,19 @@ class MammogramView(NamedTuple):
         r"""Checks if this record corresponds to a standard mammography view.
         Standard mammography views are the MLO and CC views.
         """
-        return self.view in {ViewPosition.MLO, ViewPosition.CC}
+        return self.view.is_standard_view
 
     @staticmethod
     def get_required_tags() -> List[Tag]:
         return [*Laterality.get_required_tags(), *ViewPosition.get_required_tags()]
+
+    @property
+    def is_mlo_like(self) -> bool:
+        return self.view.is_mlo_like
+
+    @property
+    def is_cc_like(self) -> bool:
+        return self.view.is_cc_like
 
 
 # Matches floats, incluidng exponential notation

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -119,6 +119,7 @@ class TestReadDicomImage:
         assert array.dtype == np.uint8
 
     @pytest.mark.ci_skip  # CircleCI will not have a GPU
+    @pytest.importorskip("pynvjpeg", reason="pynvjpeg is not installed")
     def test_nvjpeg(self, dicom_file_j2k: str, mocker):
         BATCH_SIZE: Final[int] = 1
         mocked_get_batch_size = mocker.patch("dicom_utils.dicom._nvjpeg_get_batch_size")


### PR DESCRIPTION
Local execution of `test_nvjpeg` will fail if `pynvjpeg` is not available. This will result in test failures on any local machine that does not have a GPU, or is otherwise not able to build and install `pynvjpeg`. This PR adds an `importorskip` guard to skip the test when `pynvjpeg` is not available.