### PR TITLE
Support ordering of `MammogramType`

### DIFF
--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -538,13 +538,22 @@ class ViewPosition(EnumMixin):
             return ""
         return self.name.lower()
 
+    @property
+    def is_standard_view(self) -> bool:
+        return self in {self.CC, self.MLO}
+
+    @property
+    def is_mlo_like(self) -> bool:
+        return self in {self.MLO, self.ML, self.LMO, self.LM}
+
+    @property
+    def is_cc_like(self) -> bool:
+        return self in {self.CC, self.XCCL, self.XCCM}
+
 
 class MammogramView(NamedTuple):
     laterality: Laterality = Laterality.UNKNOWN
     view: ViewPosition = ViewPosition.UNKNOWN
-
-    def __repr__(self):
-        return f"{self.laterality.short_str}{self.view.short_str}"
 
     @classmethod
     def create(cls, laterality: Optional[Laterality] = None, view: Optional[ViewPosition] = None) -> "MammogramView":
@@ -565,11 +574,19 @@ class MammogramView(NamedTuple):
         r"""Checks if this record corresponds to a standard mammography view.
         Standard mammography views are the MLO and CC views.
         """
-        return self.view in {ViewPosition.MLO, ViewPosition.CC}
+        return self.view.is_standard_view
 
     @staticmethod
     def get_required_tags() -> List[Tag]:
         return [*Laterality.get_required_tags(), *ViewPosition.get_required_tags()]
+
+    @property
+    def is_mlo_like(self) -> bool:
+        return self.view.is_mlo_like
+
+    @property
+    def is_cc_like(self) -> bool:
+        return self.view.is_cc_like
 
 
 # Matches floats, incluidng exponential notation

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -123,6 +123,27 @@ class MammogramType(EnumMixin):
     def __bool__(self) -> bool:
         return self != MammogramType.UNKNOWN
 
+    # TODO: MammogramType ordering uses the convention that x < y means x is more preferred than y
+    # We may want to change this to x > y means x is more preferred than y. This would be more intuitive
+    # but would mean `sorted(vals)` would return the values in the opposite order.
+    def is_preferred_to(self, other: "MammogramType") -> bool:
+        r"""Returns whether the current mammogram type is preferred to another.
+
+        Args:
+            other: The other mammogram type.
+
+        Returns:
+            Whether the current mammogram type is preferred to the other.
+        """
+        return self < other
+
+    @staticmethod
+    def get_best(types: List["MammogramType"]) -> "MammogramType":
+        r"""Returns the best mammogram type from a list of types."""
+        if not types:
+            raise ValueError("types must not be empty")
+        return min(types)
+
     @property
     def is_unknown(self) -> bool:
         return not bool(self)

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -103,22 +103,10 @@ class MammogramType(EnumMixin):
     SFM = 4
 
     def __lt__(self, other: "MammogramType") -> bool:
-        if self.is_unknown:
-            return False
-        elif other.is_unknown:
-            return True
-        return self.value < other.value
-
-    def __gt__(self, other: "MammogramType") -> bool:
-        if self.is_unknown and not other.is_unknown:
-            return True
-        return self.value > other.value
+        return self.is_preferred_to(other)
 
     def __le__(self, other: "MammogramType") -> bool:
-        return self < other or self == other
-
-    def __ge__(self, other: "MammogramType") -> bool:
-        return self > other or self == other
+        return self.is_preferred_to(other) or self == other
 
     def __bool__(self) -> bool:
         return self != MammogramType.UNKNOWN
@@ -135,7 +123,11 @@ class MammogramType(EnumMixin):
         Returns:
             Whether the current mammogram type is preferred to the other.
         """
-        return self < other
+        if self.is_unknown:
+            return False
+        elif other.is_unknown:
+            return True
+        return self.value < other.value
 
     @staticmethod
     def get_best(types: List["MammogramType"]) -> "MammogramType":

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -92,12 +92,40 @@ class EnumMixin(Enum):
 
 
 class MammogramType(EnumMixin):
-    r"""Enum over the subcategories of mammograms"""
+    r"""Enum over the subcategories of mammograms.
+
+    Supports the following ordering: ``TOMO < FFDM < SYNTH < SFM < UNKNOWN``
+    """
     UNKNOWN = 0
-    FFDM = 1
-    SFM = 2
+    TOMO = 1
+    FFDM = 2
     SYNTH = 3
-    TOMO = 4
+    SFM = 4
+
+    def __lt__(self, other: "MammogramType") -> bool:
+        if self.is_unknown:
+            return False
+        elif other.is_unknown:
+            return True
+        return self.value < other.value
+
+    def __gt__(self, other: "MammogramType") -> bool:
+        if self.is_unknown and not other.is_unknown:
+            return True
+        return self.value > other.value
+
+    def __le__(self, other: "MammogramType") -> bool:
+        return self < other or self == other
+
+    def __ge__(self, other: "MammogramType") -> bool:
+        return self > other or self == other
+
+    def __bool__(self) -> bool:
+        return self != MammogramType.UNKNOWN
+
+    @property
+    def is_unknown(self) -> bool:
+        return not bool(self)
 
     @staticmethod
     def get_required_tags() -> List[Tag]:

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -119,6 +119,7 @@ class TestReadDicomImage:
         assert array.dtype == np.uint8
 
     @pytest.mark.ci_skip  # CircleCI will not have a GPU
+    @pytest.importorskip("pynvjpeg", reason="pynvjpeg is not installed")
     def test_nvjpeg(self, dicom_file_j2k: str, mocker):
         BATCH_SIZE: Final[int] = 1
         mocked_get_batch_size = mocker.patch("dicom_utils.dicom._nvjpeg_get_batch_size")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -241,6 +241,10 @@ class TestMammogramType:
     )
     def test_lt(self, t1, t2, exp):
         assert (t1 < t2) == exp
+        # TODO: Move these to separate tests if we decide to change the ordering
+        # convention in the future.
+        assert t1.is_preferred_to(t2) == exp
+        assert MammogramType.get_best([t1, t2]) == (t1 if exp else t2)
 
     @pytest.mark.parametrize(
         "t1,t2,exp",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -198,6 +198,122 @@ class TestMammogramType:
     def test_from_str(self, input_str, expected):
         assert expected == MammogramType.from_str(input_str)
 
+    @pytest.mark.parametrize(
+        "val,exp",
+        [
+            (MammogramType.UNKNOWN, False),
+            *[(val, True) for val in MammogramType if val != MammogramType.UNKNOWN],
+        ],
+    )
+    def test_bool(self, val, exp):
+        assert bool(val) == exp
+
+    @pytest.mark.parametrize(
+        "val,exp",
+        [
+            (MammogramType.UNKNOWN, True),
+            *[(val, False) for val in MammogramType if val != MammogramType.UNKNOWN],
+        ],
+    )
+    def test_is_unknown(self, val, exp):
+        assert val.is_unknown == exp
+
+    @pytest.mark.parametrize(
+        "t1,t2,exp",
+        [
+            (MammogramType.FFDM, MammogramType.FFDM, False),
+            (MammogramType.FFDM, MammogramType.SYNTH, True),
+            (MammogramType.FFDM, MammogramType.TOMO, False),
+            (MammogramType.FFDM, MammogramType.SFM, True),
+            (MammogramType.SYNTH, MammogramType.FFDM, False),
+            (MammogramType.SYNTH, MammogramType.SYNTH, False),
+            (MammogramType.SYNTH, MammogramType.TOMO, False),
+            (MammogramType.TOMO, MammogramType.FFDM, True),
+            (MammogramType.TOMO, MammogramType.SYNTH, True),
+            (MammogramType.TOMO, MammogramType.TOMO, False),
+            (MammogramType.TOMO, MammogramType.SFM, True),
+            (MammogramType.UNKNOWN, MammogramType.UNKNOWN, False),
+            (MammogramType.FFDM, MammogramType.UNKNOWN, True),
+            (MammogramType.SYNTH, MammogramType.UNKNOWN, True),
+            (MammogramType.TOMO, MammogramType.UNKNOWN, True),
+            (MammogramType.SFM, MammogramType.UNKNOWN, True),
+        ],
+    )
+    def test_lt(self, t1, t2, exp):
+        assert (t1 < t2) == exp
+
+    @pytest.mark.parametrize(
+        "t1,t2,exp",
+        [
+            (MammogramType.FFDM, MammogramType.FFDM, True),
+            (MammogramType.FFDM, MammogramType.SYNTH, True),
+            (MammogramType.FFDM, MammogramType.TOMO, False),
+            (MammogramType.FFDM, MammogramType.SFM, True),
+            (MammogramType.SYNTH, MammogramType.FFDM, False),
+            (MammogramType.SYNTH, MammogramType.SYNTH, True),
+            (MammogramType.SYNTH, MammogramType.TOMO, False),
+            (MammogramType.TOMO, MammogramType.FFDM, True),
+            (MammogramType.TOMO, MammogramType.SYNTH, True),
+            (MammogramType.TOMO, MammogramType.TOMO, True),
+            (MammogramType.TOMO, MammogramType.SFM, True),
+            (MammogramType.UNKNOWN, MammogramType.UNKNOWN, True),
+            (MammogramType.FFDM, MammogramType.UNKNOWN, True),
+            (MammogramType.SYNTH, MammogramType.UNKNOWN, True),
+            (MammogramType.TOMO, MammogramType.UNKNOWN, True),
+            (MammogramType.SFM, MammogramType.UNKNOWN, True),
+        ],
+    )
+    def test_le(self, t1, t2, exp):
+        assert (t1 <= t2) == exp
+
+    @pytest.mark.parametrize(
+        "t1,t2,exp",
+        [
+            (MammogramType.FFDM, MammogramType.FFDM, False),
+            (MammogramType.FFDM, MammogramType.SYNTH, False),
+            (MammogramType.FFDM, MammogramType.TOMO, True),
+            (MammogramType.FFDM, MammogramType.SFM, False),
+            (MammogramType.SYNTH, MammogramType.FFDM, True),
+            (MammogramType.SYNTH, MammogramType.SYNTH, False),
+            (MammogramType.SYNTH, MammogramType.TOMO, True),
+            (MammogramType.TOMO, MammogramType.FFDM, False),
+            (MammogramType.TOMO, MammogramType.SYNTH, False),
+            (MammogramType.TOMO, MammogramType.TOMO, False),
+            (MammogramType.TOMO, MammogramType.SFM, False),
+            (MammogramType.UNKNOWN, MammogramType.UNKNOWN, False),
+            (MammogramType.FFDM, MammogramType.UNKNOWN, True),
+            (MammogramType.SYNTH, MammogramType.UNKNOWN, True),
+            (MammogramType.TOMO, MammogramType.UNKNOWN, True),
+            (MammogramType.SFM, MammogramType.UNKNOWN, True),
+        ],
+    )
+    def test_gt(self, t1, t2, exp):
+        assert (t1 > t2) == exp
+
+    @pytest.mark.parametrize(
+        "t1,t2,exp",
+        [
+            (MammogramType.FFDM, MammogramType.FFDM, True),
+            (MammogramType.FFDM, MammogramType.SYNTH, False),
+            (MammogramType.FFDM, MammogramType.TOMO, True),
+            (MammogramType.FFDM, MammogramType.SFM, False),
+            (MammogramType.SYNTH, MammogramType.FFDM, True),
+            (MammogramType.SYNTH, MammogramType.SYNTH, True),
+            (MammogramType.SYNTH, MammogramType.TOMO, True),
+            (MammogramType.TOMO, MammogramType.FFDM, False),
+            (MammogramType.TOMO, MammogramType.SYNTH, False),
+            (MammogramType.TOMO, MammogramType.TOMO, True),
+            (MammogramType.TOMO, MammogramType.SFM, False),
+            (MammogramType.UNKNOWN, MammogramType.UNKNOWN, True),
+            (MammogramType.FFDM, MammogramType.UNKNOWN, True),
+            (MammogramType.SYNTH, MammogramType.UNKNOWN, True),
+            (MammogramType.TOMO, MammogramType.UNKNOWN, True),
+            (MammogramType.SFM, MammogramType.UNKNOWN, True),
+        ],
+    )
+    def test_ge(self, t1, t2, exp):
+        assert (t1 >= t2) == exp
+
 
 class TestPhotometricInterpretation:
     @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -285,10 +285,11 @@ class TestMammogramType:
             (MammogramType.TOMO, MammogramType.TOMO, False),
             (MammogramType.TOMO, MammogramType.SFM, False),
             (MammogramType.UNKNOWN, MammogramType.UNKNOWN, False),
-            (MammogramType.FFDM, MammogramType.UNKNOWN, True),
-            (MammogramType.SYNTH, MammogramType.UNKNOWN, True),
-            (MammogramType.TOMO, MammogramType.UNKNOWN, True),
-            (MammogramType.SFM, MammogramType.UNKNOWN, True),
+            (MammogramType.FFDM, MammogramType.UNKNOWN, False),
+            (MammogramType.SYNTH, MammogramType.UNKNOWN, False),
+            (MammogramType.TOMO, MammogramType.UNKNOWN, False),
+            (MammogramType.SFM, MammogramType.UNKNOWN, False),
+            (MammogramType.UNKNOWN, MammogramType.FFDM, True),
         ],
     )
     def test_gt(self, t1, t2, exp):
@@ -309,10 +310,11 @@ class TestMammogramType:
             (MammogramType.TOMO, MammogramType.TOMO, True),
             (MammogramType.TOMO, MammogramType.SFM, False),
             (MammogramType.UNKNOWN, MammogramType.UNKNOWN, True),
-            (MammogramType.FFDM, MammogramType.UNKNOWN, True),
-            (MammogramType.SYNTH, MammogramType.UNKNOWN, True),
-            (MammogramType.TOMO, MammogramType.UNKNOWN, True),
-            (MammogramType.SFM, MammogramType.UNKNOWN, True),
+            (MammogramType.FFDM, MammogramType.UNKNOWN, False),
+            (MammogramType.SYNTH, MammogramType.UNKNOWN, False),
+            (MammogramType.TOMO, MammogramType.UNKNOWN, False),
+            (MammogramType.SFM, MammogramType.UNKNOWN, False),
+            (MammogramType.UNKNOWN, MammogramType.FFDM, True),
         ],
     )
     def test_ge(self, t1, t2, exp):


### PR DESCRIPTION
Enables ordering of `MammogramType` as follows: `TOMO < FFDM < SYNTH < SFM < UNKNOWN`. 

Also fixes a bug with `MammogramType.is_unknown`