### PR TITLE
Forward threads / jobs args to `ConcurrentMapper` in `organize()`

### DIFF
--- a/dicom_utils/cli/organize.py
+++ b/dicom_utils/cli/organize.py
@@ -23,13 +23,17 @@ def organize(
     namers: Iterable[str] = ["patient-id", "study-uid"],
     outputs: Iterable[str] = ["symlink-cases"],
     use_bar: bool = True,
+    jobs: Optional[int] = None,
+    threads: bool = False,
     **kwargs,
 ) -> Dict[Output, Dict[str, RecordCollection]]:
-    inp = Input(sources, records, groups, helpers, namers, use_bar=use_bar, **kwargs)
+    inp = Input(sources, records, groups, helpers, namers, use_bar=use_bar, jobs=jobs, threads=threads, **kwargs)
 
     result: Dict[Output, Dict[str, RecordCollection]] = {}
     for output_name in tqdm(outputs, desc="Writing outputs", disable=not use_bar):
-        output = OUTPUT_REGISTRY.get(output_name).instantiate_with_metadata(root=dest, use_bar=use_bar)
+        output = OUTPUT_REGISTRY.get(output_name).instantiate_with_metadata(
+            root=dest, use_bar=use_bar, jobs=jobs, threads=threads
+        )
         result[output_name] = output(inp)
 
     return result

--- a/dicom_utils/cli/organize.py
+++ b/dicom_utils/cli/organize.py
@@ -25,14 +25,30 @@ def organize(
     use_bar: bool = True,
     jobs: Optional[int] = None,
     threads: bool = False,
+    timeout: Optional[int] = None,
     **kwargs,
 ) -> Dict[Output, Dict[str, RecordCollection]]:
-    inp = Input(sources, records, groups, helpers, namers, use_bar=use_bar, jobs=jobs, threads=threads, **kwargs)
+    inp = Input(
+        sources,
+        records,
+        groups,
+        helpers,
+        namers,
+        use_bar=use_bar,
+        jobs=jobs,
+        threads=threads,
+        timeout=timeout,
+        **kwargs,
+    )
 
     result: Dict[Output, Dict[str, RecordCollection]] = {}
     for output_name in tqdm(outputs, desc="Writing outputs", disable=not use_bar):
         output = OUTPUT_REGISTRY.get(output_name).instantiate_with_metadata(
-            root=dest, use_bar=use_bar, jobs=jobs, threads=threads
+            root=dest,
+            use_bar=use_bar,
+            jobs=jobs,
+            threads=True,
+            timeout=timeout,
         )
         result[output_name] = output(inp)
 

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+import multiprocessing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partial
+from itertools import islice
 from os import PathLike
 from pathlib import Path
 from typing import (
@@ -206,6 +208,11 @@ class RecordCreator:
         return None
 
 
+def get_bar_description_suffix(jobs: Optional[int], threads: bool) -> str:
+    jobs = jobs or multiprocessing.cpu_count()
+    return f"{jobs} {'threads' if threads else 'processes'}"
+
+
 def record_iterator(
     files: Iterable[PathLike],
     jobs: Optional[int] = None,
@@ -215,6 +222,7 @@ def record_iterator(
     helpers: Iterable[str] = [],
     ignore_exceptions: bool = False,
     filters: Iterable[str] = [],
+    max_files: Optional[int] = None,
     **kwargs,
 ) -> Iterator[FileRecord]:
     r"""Produces :class:`FileRecord` instances by iterating over an input list of files. If a
@@ -264,13 +272,23 @@ def record_iterator(
     # a record creation attempt will only be made on valid files that pass all filters
 
     func = partial(creator.precheck_file, filter_funcs=filter_funcs)
+    bar_suffix = get_bar_description_suffix(jobs, threads)
+    files = files if max_files else islice(files, max_files)
     with ConcurrentMapper(threads, jobs, ignore_exceptions, chunksize=128) as mapper:
-        mapper.create_bar(desc="Scanning sources", disable=(not use_bar))
+        mapper.create_bar(
+            desc=f"Scanning sources ({bar_suffix})",
+            disable=(not use_bar),
+        )
         file_set = {Path(path) for path in mapper(func, files) if path is not None}
 
     # create and yield records
     with ConcurrentMapper(threads, jobs, ignore_exceptions, chunksize=32) as mapper:
-        mapper.create_bar(desc="Building records", total=len(file_set), unit="file", disable=(not use_bar))
+        mapper.create_bar(
+            desc=f"Building records ({bar_suffix})",
+            total=len(file_set),
+            unit="file",
+            disable=(not use_bar),
+        )
         for record in mapper(creator, file_set):
             if all(f(record) for f in filter_funcs):
                 yield record

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -393,7 +393,13 @@ class RecordCollection(Generic[R]):
         self.records: Set[R] = set(records)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(length={len(self)})"
+        types = {}
+        for record in self.records:
+            name = record.__class__.__name__
+            types.setdefault(name, 0)
+            types[name] += 1
+        root = self.common_parent_dir()
+        return f"{self.__class__.__name__}(length={len(self)}, types={types}, parent={root})"
 
     def __len__(self) -> int:
         r"""Returns the total number of contained records"""

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -399,7 +399,9 @@ class RecordCollection(Generic[R]):
             types.setdefault(name, 0)
             types[name] += 1
         root = self.common_parent_dir()
-        return f"{self.__class__.__name__}(length={len(self)}, types={types}, parent={root})"
+        sample_rec = next(iter(self.records), None)
+        sample_path = sample_rec.path if sample_rec else None
+        return f"{self.__class__.__name__}(length={len(self)}, types={types}, parent={root}, sample_path={sample_path})"
 
     def __len__(self) -> int:
         r"""Returns the total number of contained records"""
@@ -461,6 +463,8 @@ class RecordCollection(Generic[R]):
 
     def common_parent_dir(self) -> Optional[Path]:
         parents = self.parent_dirs()
+        if not parents:
+            return None
         proto = next(iter(parents))
         while proto.parent != proto:
             if all(p.is_relative_to(proto) for p in parents):

--- a/dicom_utils/container/group.py
+++ b/dicom_utils/container/group.py
@@ -7,12 +7,12 @@ import warnings
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Hashable, Iterator, List, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Callable, Dict, Hashable, Iterator, Optional, Sequence, Tuple, TypeVar, cast
 
 from registry import Registry
 from tqdm_multiprocessing import ConcurrentMapper
 
-from .collection import CollectionHelper, RecordCollection, apply_helpers
+from .collection import CollectionHelper, RecordCollection, apply_helpers, get_bar_description_suffix
 
 # Type checking fails when dataclass attr name matches a type alias.
 # Import types under a different alias
@@ -91,16 +91,28 @@ class Grouper:
         with ConcurrentMapper(self.threads, self.jobs, chunksize=self.chunksize) as mapper:
             for i, group_fn in list(enumerate(self._group_fns)):
                 # run the group function
+                total = sum(len(v) for v in result.values())
                 mapper.create_bar(
-                    desc=f"Running grouper {self.groups[i]}", disable=(not self.use_bar), leave=False, total=len(result)
+                    desc=f"Running grouper {self.groups[i]} ({get_bar_description_suffix(self.jobs, self.threads)})",
+                    disable=(not self.use_bar),
+                    leave=True,
+                    total=total,
                 )
-                mapped = mapper(self._group, list(result.items()), group_fn=group_fn)
-                result = {k: v for group_result in mapped for k, v in group_result}
+                _result: Dict[Key, RecordCollection] = {}
+                needs_grouping: Iterator[Tuple[Key, FileRecord]] = (
+                    (key, record) for key, collection in result.items() for record in collection
+                )
+                for key, record in mapper(self._group, needs_grouping, group_fn=group_fn):
+                    _result.setdefault(key, RecordCollection()).add(record)
+                result = _result
                 mapper.close_bar()
 
                 # run helpers for this stage in the grouping process
                 mapper.create_bar(
-                    desc="Running group helpers", disable=(not self.use_bar), leave=False, total=len(result)
+                    desc=f"Running group helpers ({get_bar_description_suffix(self.jobs, self.threads)})",
+                    disable=(not self.use_bar),
+                    leave=True,
+                    total=len(result),
                 )
                 mapped = mapper(self._apply_helpers, list(result.items()), index=i)
                 result = {k: v for k, v in mapped}
@@ -109,19 +121,16 @@ class Grouper:
         end_len = sum(len(collection) for collection in result.values())
         if start_len != end_len:
             warnings.warn(
-                "Grouping began with {start_len} records and ended with {end_len} records. "
+                f"Grouping began with {start_len} records and ended with {end_len} records. "
                 "This may be expected behavior depending on what helpers are being used."
             )
         return cast(Dict[Hashable, RecordCollection], result)
 
     @classmethod
-    def _group(cls, inp: Tuple[Key, RecordCollection], group_fn: GroupFunction) -> List[Tuple[Key, RecordCollection]]:
+    def _group(cls, inp: Tuple[Key, FileRecord], group_fn: GroupFunction) -> Tuple[Key, FileRecord]:
         key, entry = inp
-        result: List[Tuple[Key, RecordCollection]] = []
-        for subkey, subgroup in entry.group_by(group_fn).items():
-            new_key = key + (subkey,)
-            result.append((new_key, subgroup))
-        return result
+        key = key + (group_fn(entry),)
+        return key, entry
 
     def _apply_helpers(self, inp: Tuple[Key, RecordCollection], index: int) -> Tuple[Key, RecordCollection]:
         k, col = inp

--- a/dicom_utils/container/output.py
+++ b/dicom_utils/container/output.py
@@ -31,6 +31,7 @@ from tqdm_multiprocessing import ConcurrentMapper
 from ..types import MammogramType
 from .collection import CollectionHelper, RecordCollection
 from .collection import apply_helpers as apply_collection_helpers
+from .collection import get_bar_description_suffix
 from .input import Input
 from .protocols import SupportsGenerated
 from .record import HELPER_REGISTRY, FileRecord, MammogramFileRecord, RecordHelper, apply_helpers
@@ -141,7 +142,8 @@ class Output(ABC):
     def __call__(self, inp: Union[Input, Dict[str, Iterable[WriteResult]]]) -> Dict[str, Iterable[WriteResult]]:
         result: Dict[str, Iterable[WriteResult]] = {}
         iterable = inp if isinstance(inp, Input) else inp.items()
-        with self.mapper(total=len(iterable), desc=f"Writing {self.__class__.__name__}") as mapper:
+        desc = get_bar_description_suffix(self.jobs, self.threads)
+        with self.mapper(total=len(iterable), desc=f"Writing {self.__class__.__name__} ({desc})") as mapper:
             it = mapper(
                 self._process,
                 iterable,

--- a/dicom_utils/container/output.py
+++ b/dicom_utils/container/output.py
@@ -111,7 +111,8 @@ class Output(ABC):
         use_bar: bool = True,
         threads: bool = False,
         jobs: Optional[int] = None,
-        chunksize: int = 8,
+        chunksize: int = 1,
+        timeout: Optional[int] = None,
     ):
         self.root = Path(root)
         if not self.root.is_dir():
@@ -124,6 +125,7 @@ class Output(ABC):
         self.threads = threads
         self.jobs = jobs
         self.chunksize = chunksize
+        self.timeout = timeout
         helpers = [HELPER_REGISTRY.get(h).instantiate_with_metadata().fn for h in helpers]
         self.record_helpers: List[RecordHelper] = [h for h in helpers if isinstance(h, RecordHelper)]
         self.collection_helpers: List[CollectionHelper] = [h for h in helpers if isinstance(h, CollectionHelper)]
@@ -133,7 +135,7 @@ class Output(ABC):
         return self.root / self.output_subdir
 
     def mapper(self, **kwargs) -> ConcurrentMapper:
-        mapper = ConcurrentMapper(self.threads, self.jobs, chunksize=self.chunksize)
+        mapper = ConcurrentMapper(self.threads, self.jobs, chunksize=self.chunksize, timeout=self.timeout)
         kwargs.setdefault("disable", not self.use_bar)
         kwargs.setdefault("leave", False)
         mapper.create_bar(**kwargs)

--- a/tests/test_container/test_collection.py
+++ b/tests/test_container/test_collection.py
@@ -292,3 +292,8 @@ class TestRecordCollection:
         rec2 = DicomFileRecord(path=Path("bar.dcm"), SOPInstanceUID=SOPUID("123"), StudyInstanceUID=StudyUID("123"))
         col = RecordCollection([rec1, rec2])
         assert len(col) == 1
+
+    def test_repr(self, tmp_path, collection):
+        result = repr(collection)
+        expected = f"RecordCollection(length=9, types={{'DicomImageFileRecord': 9}}, parent={tmp_path})"
+        assert result == expected

--- a/tests/test_container/test_collection.py
+++ b/tests/test_container/test_collection.py
@@ -295,5 +295,10 @@ class TestRecordCollection:
 
     def test_repr(self, tmp_path, collection):
         result = repr(collection)
-        expected = f"RecordCollection(length=9, types={{'DicomImageFileRecord': 9}}, parent={tmp_path})"
-        assert result == expected
+        expected_start = f"RecordCollection(length=9, types={{'DicomImageFileRecord': 9}}, parent={tmp_path}"
+        assert result.startswith(expected_start)
+
+    def test_repr_empty(self):
+        result = repr(RecordCollection())
+        expected_start = "RecordCollection(length=0, types={}, parent=None"
+        assert result.startswith(expected_start)

--- a/tests/test_main/test_organize.py
+++ b/tests/test_main/test_organize.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+import tqdm_multiprocessing
 
 from dicom_utils.cli.organize import organize
 from dicom_utils.dicom_factory import CompleteMammographyStudyFactory, DicomFactory
@@ -39,3 +40,28 @@ class TestSymlinkPipeline:
             recs = {k: [r.path.relative_to(dest) for r in v] for k, v in results.items()}
             assert len(recs) == num_cases
             assert all(v for v in recs.values())
+
+    @pytest.mark.parametrize("threads", [True, False])
+    @pytest.mark.parametrize("jobs", [4, 8])
+    def test_forward_jobs_and_threads(self, tmp_path, mocker, threads, jobs):
+        spy = mocker.spy(tqdm_multiprocessing.ConcurrentMapper, "__init__")
+
+        paths = []
+        for i in range(num_cases := 3):
+            factory = CompleteMammographyStudyFactory(
+                seed=i,
+            )
+            case_dir = Path(tmp_path, f"Original-{i}")
+            case_dir.mkdir(parents=True)
+            dicoms = factory(StudyInstanceUID=f"study-{i}")
+            outputs = DicomFactory.save_dicoms(case_dir, dicoms)
+            paths.append(outputs)
+
+        dest = Path(tmp_path, "symlinks")
+        dest.mkdir()
+        # set use_bar = True to help debugging
+        organize(tmp_path, dest, use_bar=False, jobs=jobs, threads=threads)
+        assert spy.call_count == 4
+        for i, call in enumerate(spy.call_args_list):
+            assert call.args[0].threads == threads, f"call {i} failed"
+            assert call.args[0].jobs == jobs, f"call {i} failed"

--- a/tests/test_main/test_organize.py
+++ b/tests/test_main/test_organize.py
@@ -60,8 +60,14 @@ class TestSymlinkPipeline:
         dest = Path(tmp_path, "symlinks")
         dest.mkdir()
         # set use_bar = True to help debugging
-        organize(tmp_path, dest, use_bar=False, jobs=jobs, threads=threads)
-        assert spy.call_count == 4
+        timeout = 2
+        organize(tmp_path, dest, use_bar=False, jobs=jobs, threads=threads, timeout=timeout)
+        assert spy.call_count == 3
         for i, call in enumerate(spy.call_args_list):
-            assert call.args[0].threads == threads, f"call {i} failed"
+            if i not in (1, 2):
+                assert call.args[0].threads == threads, f"call {i} failed"
+            else:
+                # Grouper has thread override because of deadlocks
+                assert call.args[0].threads, f"call {i} failed"
             assert call.args[0].jobs == jobs, f"call {i} failed"
+            assert call.args[0].timeout == timeout, f"call {i} failed"


### PR DESCRIPTION
When calling `organize()` with a given configuration of `jobs` and `threads`, these parameters were not properly forwarded to all instances of `ConcurrentMapper()` used throughout the organization process. This could result in unexpected behavior (deadlocks or memory overflow) when used on a high core count machine with a large number of input files (100k+). Such deadlocks appear to be more common in the grouping or output stages.

This PR makes the following changes:
* Improve `RecordCollection` repr to help debugging
* Ensure (with tests) that all uses of `ConcurrentMapper()` in `organize()` receive `threads` and `jobs` as expected
* Report the number of threads or processes in tqdm bars for clarity
* Refactor the first grouping stage to take advantage of parallelism. Previously, the first grouping stage would only execute on a single thread/process

Outstanding issues:
* It is not clear why memory usage is such an issue at high process counts. It may be helpful to explore the cause further
* It is not clear if these changes are sufficient to avoid deadlocks