### PR TITLE
Add presentation type that can bypass VOILUT

### DIFF
--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -50,7 +50,7 @@ TransferSyntaxUIDs: Final[Dict[str, str]] = {
 
 
 # Used to indicate preprocessed DICOMs
-ALGORITHM_PRESENTATION_TYPE: Final = "FOR MEDCOG ALGORITHM"
+ALGORITHM_PRESENTATION_TYPE: Final = "FOR ALGORITHM"
 
 
 # Pillow is relatively slow so we want to make sure that other handlers are used instead

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -18,7 +18,7 @@ from pydicom.uid import UID, ExplicitVRLittleEndian, ImplicitVRLittleEndian, JPE
 from .basic_offset_table import BasicOffsetTable
 from .logging import logger
 from .tags import Tag
-from .types import Dicom, PhotometricInterpretation, iterate_shared_functional_groups
+from .types import Dicom, PhotometricInterpretation, get_value, iterate_shared_functional_groups
 from .volume import KeepVolume, VolumeHandler
 
 
@@ -47,6 +47,10 @@ TransferSyntaxUIDs: Final[Dict[str, str]] = {
     "1.2.840.10008.1.2.4.92": "JPEG2000 Multi-component Lossless",
     "1.2.840.10008.1.2.4.93": "JPEG2000 Multi-component",
 }
+
+
+# Used to indicate preprocessed DICOMs
+ALGORITHM_PRESENTATION_TYPE: Final = "FOR MEDCOG ALGORITHM"
 
 
 # Pillow is relatively slow so we want to make sure that other handlers are used instead
@@ -125,9 +129,14 @@ def strict_dcm_to_pixels(dcm: Dicom, dims: Tuple[int, ...]) -> ndarray:
     Returns:
         Numpy ndarray of pixel data
     """
-    try:
-        pixels = apply_voi_lut(dcm.pixel_array, dcm)
-    except Exception:
+    # Preprocessed images will set a specific PresentationIntentType.
+    # Check this to ensure we don't reapply the VOI LUT or other pixel adjustment operations
+    if get_value(dcm, Tag.PresentationIntentType, "") != ALGORITHM_PRESENTATION_TYPE:
+        try:
+            pixels = apply_voi_lut(dcm.pixel_array, dcm)
+        except Exception:
+            pixels = dcm.pixel_array
+    else:
         pixels = dcm.pixel_array
     return pixels.reshape(dims)
 

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -303,7 +303,7 @@ def read_dicom_image(
         pixels = pixels.newbyteorder("=")
 
     # in some dicoms, pixel value of 0 indicates white
-    if pm.is_inverted:
+    if pm.is_inverted and get_value(dcm, Tag.PresentationIntentType, "") != ALGORITHM_PRESENTATION_TYPE:
         pixels = invert_color(pixels)
 
     # convert to uint8 if requested

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -207,10 +207,13 @@ class TestReadDicomImage:
         ],
     )
     def test_for_algorithm_presentation_handling(self, mocker, dicom_object, presentation, exp):
-        m = mocker.patch("dicom_utils.dicom.apply_voi_lut", return_value=dicom_object.pixel_array)
+        m1 = mocker.patch("dicom_utils.dicom.apply_voi_lut", return_value=dicom_object.pixel_array)
+        m2 = mocker.patch("dicom_utils.dicom.invert_color", return_value=dicom_object.pixel_array)
         dicom_object.PresentationIntentType = presentation
+        dicom_object.PhotometricInterpretation = "MONOCHROME1"
         read_dicom_image(dicom_object)
-        assert m.called == exp
+        assert m1.called == exp, "apply_voi_lut not called as expected"
+        assert m2.called == exp, "invert_color not called as expected"
 
 
 @pytest.mark.ci_skip  # CircleCI will not have a GPU


### PR DESCRIPTION
The implementation of `read_dicom_image()` will automatically apply pixel adjustments including windowing and inversion. However, if we read a DICOM with these corrections applied and then attempt to update the pixel data of the original DICOM, behavior at time of next DICOM read will be incorrect. One solution is to update all of the tags involved in applying these corrections, however that is involved and not robust. This PR solves the issue by adding a new `PresentationIntentType` keyword, the presence of which will disable VOILUT and inversion transforms.