### PR TITLE
Ensure `FileRecord.from_dict` attaches a path

### DIFF
--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -333,7 +333,7 @@ class FileRecord:
         for k, v in target.items():
             if k in dest_fields:
                 kwargs[k] = v
-        record_path = kwargs.pop("path")
+        record_path = Path(kwargs.pop("path"))
         rec = cls(record_path, **kwargs)
         return rec
 

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -236,6 +236,7 @@ class TestFileRecord:
         assert rec_dict["resolved_path"] == str(rec.path.resolve().absolute())
         restored = FileRecord.from_dict(rec_dict)
         assert isinstance(restored, type(rec))
+        assert isinstance(restored.path, Path)
         assert restored == rec
 
 


### PR DESCRIPTION
Fixes potential issues when reconstructing records from dicts.