### PR TITLE
Allow `dcm` as an arg to `RecordCreator.__call__`

### DIFF
--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -135,9 +135,8 @@ class RecordCreator:
                     "It may be still used elsewhere"
                 )
 
-    def __call__(self, path: Path) -> FileRecord:
+    def __call__(self, path: Path, dcm: Optional[Dicom] = None) -> FileRecord:
         result = FileRecord.from_file(path)
-        dcm: Optional[Dicom] = None
 
         for dtype in self.iterate_types_to_try(path):
             try:
@@ -182,10 +181,8 @@ class RecordCreator:
         dicom_candidates = set(self.filter_dicom_types(candidates))
         non_dicom_candidates = set(candidates) - dicom_candidates
 
-        for c in self.sort_by_subclass_level(dicom_candidates):
-            yield c
-        for c in self.sort_by_subclass_level(non_dicom_candidates):
-            yield c
+        yield from self.sort_by_subclass_level(dicom_candidates)
+        yield from self.sort_by_subclass_level(non_dicom_candidates)
 
     @classmethod
     def sort_by_subclass_level(cls, types: Iterable[Type[FileRecord]]) -> List[Type[FileRecord]]:

--- a/dicom_utils/container/collection.py
+++ b/dicom_utils/container/collection.py
@@ -136,7 +136,7 @@ class RecordCreator:
                 )
 
     def __call__(self, path: Path, dcm: Optional[Dicom] = None) -> FileRecord:
-        result = FileRecord.from_file(path)
+        result = FileRecord(path)
 
         for dtype in self.iterate_types_to_try(path):
             try:

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -333,7 +333,7 @@ class FileRecord:
         for k, v in target.items():
             if k in dest_fields:
                 kwargs[k] = v
-        record_path = kwargs.pop("path")
+        record_path = Path(kwargs.pop("path"))
         rec = cls(record_path, **kwargs)
         return rec
 

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -236,6 +236,7 @@ class TestFileRecord:
         assert rec_dict["resolved_path"] == str(rec.path.resolve().absolute())
         restored = FileRecord.from_dict(rec_dict)
         assert isinstance(restored, type(rec))
+        assert isinstance(restored.path, Path)
         assert restored == rec
 
 


### PR DESCRIPTION
This allows `RecordCreator` to be used with existing DICOM objects