### PR TITLE
Add `get_opposing_laterality` method

### DIFF
--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -1002,6 +1002,38 @@ class MammogramFileRecord(DicomImageFileRecord):
             result[mammo_view] = selection
         return result
 
+    def get_opposing_laterality(self, col: Iterable["MammogramFileRecord"]) -> Optional["MammogramFileRecord"]:
+        r"""Selects a complementary view of the opposing laterality from a collection of :class:`MammogramFileRecord`s.
+        For example, the complementary view of a left MLO is a right MLO.
+
+        Args:
+            col: Collection to select from
+
+        Returns:
+            The selected view (or `None` if a view could not be found).
+        """
+        valid_laterality = self.laterality in {Laterality.LEFT, Laterality.RIGHT}
+        valid_view = not (self.view_position is None or self.view_position.is_unknown)
+        if not (valid_laterality and valid_view):
+            return
+
+        # Target laterality is opposite of this view
+        target_laterality = Laterality.LEFT if self.laterality == Laterality.RIGHT else Laterality.RIGHT
+        # Target view is same as this view
+        target_view = cast(ViewPosition, self.view_position)
+
+        candidates = self.get_preferred_views(
+            {
+                rec
+                for rec in col
+                if isinstance(rec, MammogramFileRecord)
+                and rec.laterality == target_laterality
+                and rec.view_position == target_view
+            }
+        )
+        result = candidates.get(MammogramView(target_laterality, target_view), None)
+        return cast(Optional[MammogramFileRecord], result)
+
     def standardized_filename(self, file_id: Optional[str] = None) -> StandardizedFilename:
         r"""Returns a standardized filename for the DICOM represented by this :class:`DicomFileRecord`.
         File name will be of the form ``{file_type}_{modifiers}_{view}_{file_id}.dcm``.

--- a/dicom_utils/container/record.py
+++ b/dicom_utils/container/record.py
@@ -1018,7 +1018,7 @@ class MammogramFileRecord(DicomImageFileRecord):
             return
 
         # Target laterality is opposite of this view
-        target_laterality = Laterality.LEFT if self.laterality == Laterality.RIGHT else Laterality.RIGHT
+        target_laterality = cast(Laterality, self.laterality).opposite
         # Target view is same as this view
         target_view = cast(ViewPosition, self.view_position)
 

--- a/dicom_utils/types.py
+++ b/dicom_utils/types.py
@@ -339,6 +339,14 @@ class Laterality(EnumMixin):
     BILATERAL = 3
 
     @property
+    def opposite(self) -> "Laterality":
+        if self == Laterality.LEFT:
+            return Laterality.RIGHT
+        elif self == Laterality.RIGHT:
+            return Laterality.LEFT
+        return Laterality.UNKNOWN
+
+    @property
     def is_unilateral(self) -> bool:
         return self in (Laterality.LEFT, Laterality.RIGHT)
 

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -1663,3 +1663,54 @@ class TestMammogramFileRecord(TestDicomFileRecord):
         restored = FileRecord.from_dict(rec_dict)
         assert isinstance(restored, MammogramFileRecord)
         assert restored.is_spot_compression
+
+    @pytest.mark.parametrize(
+        "src,others,exp",
+        [
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.MLO),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.MLO),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                    MammogramFileRecord(Path("foo3.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.MLO),
+                    MammogramFileRecord(Path("foo4.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.CC),
+                ],
+                MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.MLO),
+            ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.MLO),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                    MammogramFileRecord(Path("foo3.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.MLO),
+                    MammogramFileRecord(Path("foo4.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.CC),
+                ],
+                MammogramFileRecord(Path("foo4.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.CC),
+            ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.MLO),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                ],
+                None,
+            ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.CC),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.XCCL),
+                ],
+                None,
+            ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.CC),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.XCCL),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                ],
+                MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+            ),
+        ],
+    )
+    def test_get_opposing_laterality(self, src, others, exp):
+        assert src.get_opposing_laterality(others) == exp

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -1710,6 +1710,30 @@ class TestMammogramFileRecord(TestDicomFileRecord):
                 ],
                 MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
             ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.UNKNOWN, view_position=ViewPosition.CC),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.XCCL),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                ],
+                None,
+            ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.BILATERAL, view_position=ViewPosition.CC),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.XCCL),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                ],
+                None,
+            ),
+            (
+                MammogramFileRecord(Path("foo.dcm"), laterality=Laterality.LEFT, view_position=ViewPosition.UNKNOWN),
+                [
+                    MammogramFileRecord(Path("foo1.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.XCCL),
+                    MammogramFileRecord(Path("foo2.dcm"), laterality=Laterality.RIGHT, view_position=ViewPosition.CC),
+                ],
+                None,
+            ),
         ],
     )
     def test_get_opposing_laterality(self, src, others, exp):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -524,6 +524,19 @@ class TestLaterality:
         x = Laterality.from_dicom(dicom_object)
         assert x == Laterality.UNKNOWN
 
+    @pytest.mark.parametrize(
+        "lat,expected",
+        [
+            (Laterality.RIGHT, Laterality.LEFT),
+            (Laterality.LEFT, Laterality.RIGHT),
+            (Laterality.BILATERAL, Laterality.UNKNOWN),
+            (Laterality.UNKNOWN, Laterality.UNKNOWN),
+            (Laterality.NONE, Laterality.UNKNOWN),
+        ],
+    )
+    def test_opposite(self, lat, expected):
+        assert lat.opposite == expected
+
 
 class TestViewPosition:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Adds a method to select a complementary view of opposing laterality from a collection of mammograms.