### PR TITLE
Automatically apply DBT VOI_LUT correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,4 @@ coverage.xml
 dicom_utils/version.py
 tmp
 **/*.orig
-.pdm.toml
+.pdm-python

--- a/dicom_utils/dicom.py
+++ b/dicom_utils/dicom.py
@@ -284,6 +284,11 @@ def read_dicom_image(
         D: int = int(dcm.get("NumberOfFrames", 1))
         dims = (C, D, *dims[-2:]) if D > 1 else (C, *dims[-2:])
 
+        # Some 3D dicoms have window information in a different location.
+        # If no window information is found in the standard location, run a function to copy it from the other location.
+        if not hasattr(dcm, "WindowCenter") or not hasattr(dcm, "WindowWidth"):
+            dcm = convert_frame_voi_lut(dcm)
+
     # decompress with GPU if requested
     # TODO If the volume handler is ReduceVolume, we should be decompressing
     # before the handler is applied instead of after.

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -10,6 +10,7 @@ import pytest
 from numpy.random import default_rng
 from pydicom.uid import ImplicitVRLittleEndian, RLELossless
 
+import dicom_utils
 from dicom_utils import KeepVolume, SliceAtLocation, UniformSample, read_dicom_image
 from dicom_utils.dicom import (
     ALGORITHM_PRESENTATION_TYPE,
@@ -96,6 +97,20 @@ class TestReadDicomImage:
         spy.assert_called_once()
         assert spy.mock_calls[0].args[0] == dcm, "handler should be called with DICOM object"
         assert array1.ndim < 4 or array1.shape[1] != 1, "3D dim should be squeezed when D=1"
+
+    @pytest.mark.parametrize("has_voi_lut", [True, False])
+    def test_convert_3d_voi_lut(self, mocker, dicom_object_3d, has_voi_lut):
+        dcm = dicom_object_3d(num_frames=8)
+        if has_voi_lut:
+            dcm.WindowCenter = 512
+            dcm.WindowWidth = 512
+
+        spy = mocker.spy(dicom_utils.dicom, "convert_frame_voi_lut")
+        read_dicom_image(dcm, strict_interp=True)
+        if has_voi_lut:
+            spy.assert_not_called()
+        else:
+            spy.assert_called_once()
 
     def test_decoding_speed(self, dicom_file_j2k: str) -> None:
         # Make sure that our set of pixel data handlers is actually faster than the default set


### PR DESCRIPTION
Most DBT images store VOI_LUT window information in a different location than FFDM images. We already had a method that can read handle this difference, but it was not being applied as part of `read_dicom_image()`. This PR ensures that we apply the VOI_LUT correction when reading the image, yielding results with much better contrast.

<img src=https://user-images.githubusercontent.com/17323968/232610156-5ad2a531-560b-4985-bc2b-90e3bd516900.png height=512 width=384>
<img src=https://user-images.githubusercontent.com/17323968/232610161-66d7bbec-93ed-4aeb-b70b-7f6b3173e27d.png height=512 width=384>
