### PR TITLE
Allow VolumeHandler in dicom2img

### DIFF
--- a/dicom_utils/__init__.py
+++ b/dicom_utils/__init__.py
@@ -12,7 +12,15 @@ from .anonymize import anonymize
 from .dicom import NoImageError, read_dicom_image
 from .dicom_factory import DicomFactory
 from .metadata import add_patient_age, dicom_to_json, drop_fields_by_length, get_date
-from .volume import KeepVolume, RandomSlice, ReduceVolume, SliceAtLocation, UniformSample, VolumeHandler
+from .volume import (
+    VOLUME_HANDLERS,
+    KeepVolume,
+    RandomSlice,
+    ReduceVolume,
+    SliceAtLocation,
+    UniformSample,
+    VolumeHandler,
+)
 
 
 try:
@@ -63,4 +71,5 @@ __all__ = [
     "UniformSample",
     "ReduceVolume",
     "RandomSlice",
+    "VOLUME_HANDLERS",
 ]

--- a/dicom_utils/cli/dicom2img.py
+++ b/dicom_utils/cli/dicom2img.py
@@ -191,7 +191,8 @@ def main(args: argparse.Namespace) -> None:
     if dest is not None and dest.is_dir():
         dest = Path(dest, path.stem).with_suffix(".png")
 
-    volume_handler = VOLUME_HANDLERS.get(args.volume_handler).instantiate_with_metadata()
+    volume_handler = VOLUME_HANDLERS.get(args.volume_handler).instantiate_with_metadata().fn
+    assert isinstance(volume_handler, VolumeHandler)
 
     dcms = list(path_to_dicoms(path))
     dicoms_to_graphic(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def dicom_file_j2k(request):
 @pytest.fixture
 def dicom_file_3d(tmp_path, dicom_object_3d):
     path = Path(tmp_path, "CT_small_3D.dcm")
-    dicom_file_3d.save_as(path)
+    dicom_object_3d(num_frames=32).save_as(path)
     return path
 
 

--- a/tests/test_main/test_dicom2img.py
+++ b/tests/test_main/test_dicom2img.py
@@ -71,6 +71,24 @@ def test_dicom2img(dicom_image_file, dicom_annotation_file, tmp_path, out):
         assert locals()["path"].is_file()
 
 
+@pytest.mark.parametrize(
+    "out", [pytest.param(None, marks=pytest.mark.xfail(raises=NotImplementedError, strict=True)), "foo.gif"]
+)
+@pytest.mark.parametrize("handler", ["keep", "max-8-5"])
+def test_dicom2img_3d(dicom_file_3d, tmp_path, out, handler):
+    sys.argv = [sys.argv[0], str(tmp_path), "--noblock", "-v", handler]
+
+    if out is not None:
+        path = Path(tmp_path, out)
+        sys.argv.extend(["--output", str(path)])
+
+    runpy.run_module("dicom_utils.cli.dicom2img", run_name="__main__", alter_sys=True)
+
+    if out is not None:
+        assert "path" in locals()
+        assert locals()["path"].is_file()
+
+
 def test_bytes(dicom_image_file, dicom_annotation_file, tmp_path, capsysbinary):
     sys.argv = [sys.argv[0], str(tmp_path), "--noblock", "--bytes"]
 


### PR DESCRIPTION
Replaces the `--volume` boolean arg with an option to use any registered `VolumeHandler()`. Adds a `VOLUME_HANDLERS` registry with some default volume handlers. 