### PR TITLE
Handle DICOMs with improper suffixes

### DIFF
--- a/tests/test_container/test_collection.py
+++ b/tests/test_container/test_collection.py
@@ -141,14 +141,19 @@ class TestIterateInputPath:
 
 
 @pytest.fixture
-def dicom_files(tmp_path, dicom_file):
+def suffix():
+    return ".dcm"
+
+
+@pytest.fixture
+def dicom_files(tmp_path, dicom_file, suffix):
     paths = []
     factory = DicomFactory(proto=dicom_file)
     for i in range(3):
         for j in range(3):
             study_uid = f"study_{i}"
             sop_uid = f"study_{i}_sop_{j}"
-            dest = Path(tmp_path, f"subdir_{i}", f"file_{j}.dcm")
+            dest = Path(tmp_path, f"subdir_{i}", f"file_{j}{suffix}")
             dest.parent.mkdir(exist_ok=True, parents=True)
 
             dcm = factory(StudyInstanceUID=study_uid, SOPInstanceUID=sop_uid)
@@ -205,6 +210,7 @@ class TestRecordCreator:
 
 
 class TestRecordIterator:
+    @pytest.mark.parametrize("suffix", [".dcm", "", ".123"])
     @pytest.mark.parametrize("use_bar", [True, False])
     @pytest.mark.parametrize("threads", [False, True])
     @pytest.mark.parametrize("jobs", [None, 1, 2])

--- a/tests/test_container/test_input.py
+++ b/tests/test_container/test_input.py
@@ -9,11 +9,16 @@ from dicom_utils.container.input import Input
 
 
 @pytest.fixture
-def dicom_files(tmp_path, dicom_file):
+def suffix():
+    return ".dcm"
+
+
+@pytest.fixture
+def dicom_files(tmp_path, dicom_file, suffix):
     paths = []
     for i in range(3):
         for j in range(3):
-            dest = Path(tmp_path, f"subdir_{i}", f"file_{j}.dcm")
+            dest = Path(tmp_path, f"subdir_{i}", f"file_{j}{suffix}")
             dest.parent.mkdir(exist_ok=True, parents=True)
             shutil.copy(dicom_file, str(dest))
             paths.append(dest)
@@ -21,6 +26,7 @@ def dicom_files(tmp_path, dicom_file):
 
 
 class TestInput:
+    @pytest.mark.parametrize("suffix", [".dcm", "", ".123"])
     def test_basic_input(self, tmp_path, dicom_files):
         source = tmp_path
         Path(tmp_path, "dest")

--- a/tests/test_container/test_record.py
+++ b/tests/test_container/test_record.py
@@ -282,6 +282,14 @@ class TestDicomFileRecord(TestFileRecord):
         proto.__class__.from_file(proto.path)
         spy.assert_called_once()
 
+    def test_from_file_bad_suffix(self, tmp_path, mocker, record_factory):
+        proto = record_factory()
+        new_path = Path(f"{proto.path}.123")
+        shutil.copy(proto.path, new_path)
+        rec = proto.__class__.from_file(new_path)
+        assert rec.__class__ == proto.__class__
+        assert rec.path == new_path
+
     @pytest.mark.parametrize("file_exists", [True, False])
     def test_from_dicom(self, mocker, record_factory, file_exists):
         proto = record_factory()


### PR DESCRIPTION
Includes fixes for files with names like `1.2.345` (no suffix, filename with periods). When encountering a file with a suffix that is all numerical digits, or that is greater than length 5, we will try all possible record types.