### PR TITLE
Support applying rescale from metadata

### DIFF
--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -246,6 +246,16 @@ class TestReadDicomImage:
         assert (array1 != array2).any()
         assert spy.call_count == 1
 
+    def test_rescale_control(self, mocker, dicom_object):
+        np.random.seed(42)
+        spy = mocker.spy(dicom_utils.dicom, "apply_rescale")
+        dicom_object.RescaleIntercept = 1
+        dicom_object.RescaleSlope = 2
+        array1 = read_dicom_image(dicom_object, rescale=True)
+        array2 = read_dicom_image(dicom_object, rescale=False)
+        assert (array1 != array2).any()
+        assert spy.call_count == 1
+
 
 @pytest.mark.ci_skip  # CircleCI will not have a GPU
 @pytest.mark.usefixtures("pynvjpeg")

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -30,19 +30,19 @@ class TestReadDicomImage:
         assert array.shape[2] == 128, "width dim size == 128"
 
     def test_array_dtype(self, dicom_object):
-        array = read_dicom_image(dicom_object)
+        array = read_dicom_image(dicom_object, rescale=False)
         assert isinstance(array, np.ndarray)
         assert array.dtype == np.int16
 
     def test_min_max_values(self, dicom_object):
-        array = read_dicom_image(dicom_object)
+        array = read_dicom_image(dicom_object, rescale=False)
         assert isinstance(array, np.ndarray)
         assert array.min() == 128, "min pixel value 128"
         assert array.max() == 2191, "max pixel value 2191"
 
     def test_invalid_TransferSyntaxUID_loose_interpretation(self, dicom_object):
         dicom_object.file_meta.TransferSyntaxUID = "1.2.840.10008.1.2.4.90"  # Assign random invalid TransferSyntaxUID
-        array = read_dicom_image(dicom_object, use_nvjpeg=False)
+        array = read_dicom_image(dicom_object, use_nvjpeg=False, rescale=False)
         assert isinstance(array, np.ndarray)
         assert array.min() == 128, "min pixel value 128"
         assert array.max() == 2191, "max pixel value 2191"


### PR DESCRIPTION
This is necessary to produce images with adequate contrast in some situations (CT scans in particular).