### PR TITLE
Fix maximum pixel value for DICOM factory

### DIFF
--- a/dicom_utils/dicom_factory.py
+++ b/dicom_utils/dicom_factory.py
@@ -67,7 +67,7 @@ class BaseFactory(ABC):
         seed: int = 42,
     ) -> np.ndarray:
         low = 0
-        high = BitsAllocated
+        high = 2**BitsAllocated - 1
         channels = 1 if PhotometricInterpretation.startswith("MONOCHROME") else 3
         size = tuple(x for x in (channels, NumberOfFrames, Rows, Columns) if x > 1)
         rng = default_rng(seed)

--- a/tests/test_dicom_factory.py
+++ b/tests/test_dicom_factory.py
@@ -44,6 +44,9 @@ class TestDicomFactory:
         arr = DicomFactory.pixel_array_from_dicom(factory.dicom)
         assert isinstance(arr, np.ndarray)
         assert arr.shape == (128, 128)
+        # Should be deterministic for a given seed
+        assert arr.min() == 9
+        assert arr.max() == 65523
 
     @pytest.mark.parametrize("meaning", ["foo", "bar"])
     def test_code_sequence(self, meaning):


### PR DESCRIPTION
Note this may break existing tests in downstream repos that depend on the generated pixel values